### PR TITLE
[mobile] add mobile friendly module and branding

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,7 @@ find_package(Calamares 3.2.26 REQUIRED)
 # the (single) branding for your distro.
 #
 calamares_add_branding_subdirectory( branding/default NAME default )
+calamares_add_branding_subdirectory( branding/default-mobile NAME default-mobile )
 calamares_add_branding_subdirectory( branding/fancy NAME fancy )
 
 # This one has files in subdirectories
@@ -54,6 +55,7 @@ set(SKIPPED_MODULES "")
 
 calamares_add_module_subdirectory( modules/filekeeper )  # C++ job
 calamares_add_module_subdirectory( modules/freebsddisk )  # C++ viewmodule
+calamares_add_module_subdirectory( modules/mobile )
 calamares_add_module_subdirectory( modules/slowpython )  # Python job
 
 # If modules cannot be built, they usually call a macro

--- a/branding/default-mobile/branding.desc
+++ b/branding/default-mobile/branding.desc
@@ -1,0 +1,179 @@
+# Product branding information. This influences some global
+# user-visible aspects of Calamares, such as the product
+# name, window behavior, and the slideshow during installation.
+#
+# Additional styling can be done using the stylesheet.qss
+# file, also in the branding directory.
+---
+componentName:  default-mobile
+
+# This selects between different welcome texts. When false, uses
+# the traditional "Welcome to the %1 installer.", and when true,
+# uses "Welcome to the Calamares installer for %1." This allows
+# to distinguish this installer from other installers for the
+# same distribution.
+welcomeStyleCalamares:   false
+
+# Should the welcome image (productWelcome, below) be scaled
+# up beyond its natural size? If false, the image does not grow
+# with the window but remains the same size throughout (this
+# may have surprising effects on HiDPI monitors).
+welcomeExpandingLogo:   true
+
+# Size and expansion policy for Calamares.
+#  - "normal" or unset, expand as needed, use *windowSize*
+#  - "fullscreen", start as large as possible, ignore *windowSize*
+#  - "noexpand", don't expand automatically, use *windowSize*
+windowExpanding:    fullscreen
+
+# Size of Calamares window, expressed as w,h. Both w and h
+# may be either pixels (suffix px) or font-units (suffix em).
+#   e.g.    "800px,600px"
+#           "60em,480px"
+# This setting is ignored if "fullscreen" is selected for
+# *windowExpanding*, above. If not set, use constants defined
+# in CalamaresUtilsGui, 800x520.
+windowSize: 800px,520px
+
+# Placement of Calamares window. Either "center" or "free".
+# Whether "center" actually works does depend on the window
+# manager in use (and only makes sense if you're not using
+# *windowExpanding* set to "fullscreen").
+windowPlacement: center
+
+# Kind of sidebar (panel on the left, showing progress).
+#  - "widget" or unset, use traditional sidebar (logo, items)
+#  - "none", hide it entirely
+#  - "qml", use calamares-sidebar.qml from branding folder
+# In addition, you **may** specify a side, separated by a comma,
+# from the kind. Valid sides are:
+#  - "left" (if not specified, uses this)
+#  - "right"
+#  - "top"
+#  - "bottom"
+# For instance, "widget,right" is valid; so is "qml", which defaults
+# to putting the sidebar on the left. Also valid is "qml,top".
+# While "widget,top" is valid, the widgets code is **not** flexible
+# and results will be terrible.
+sidebar: none
+
+# Kind of navigation (button panel on the bottom).
+#  - "widget" or unset, use traditional navigation
+#  - "none", hide it entirely
+#  - "qml", use calamares-navigation.qml from branding folder
+# In addition, you **may** specify a side, separated by a comma,
+# from the kind. The same sides are valid as for *sidebar*,
+# except the default is *bottom*.
+navigation: none
+
+# These are strings shown to the user in the user interface.
+# There is no provision for translating them -- since they
+# are names, the string is included as-is.
+#
+# The four Url strings are the Urls used by the buttons in
+# the welcome screen, and are not shown to the user. Clicking
+# on the "Support" button, for instance, opens the link supportUrl.
+# If a Url is empty, the corresponding button is not shown.
+#
+# bootloaderEntryName is how this installation / distro is named
+# in the boot loader (e.g. in the GRUB menu).
+#
+# These strings support substitution from /etc/os-release
+# if KDE Frameworks 5.58 are available at build-time. When
+# enabled, @{var-name} is replaced by the equivalent value
+# from os-release. All the supported var-names are in all-caps,
+# and are listed on the FreeDesktop.org site,
+#       https://www.freedesktop.org/software/systemd/man/os-release.html
+# Note that ANSI_COLOR and CPE_NAME don't make sense here, and
+# are not supported (the rest are). Remember to quote the string
+# if it contains substitutions, or you'll get YAML exceptions.
+#
+# The *Url* entries are used on the welcome page, and they
+# are visible as buttons there if the corresponding *show* keys
+# are set to "true" (they can also be overridden).
+strings:
+    productName:         "NextGenMobileLinuxDistro"
+    shortProductName:    NextGenMobileLinuxDistro
+
+# These images are loaded from the branding module directory.
+#
+# productBanner is an optional image, which if present, will be shown
+#       on the welcome page of the application, above the welcome text.
+#       It is intended to have a width much greater than height.
+#       It is displayed at 64px height (also on HiDPI).
+#       Recommended size is 64px tall, and up to 460px wide.
+# productIcon is used as the window icon, and will (usually) be used
+#       by the window manager to represent the application. This image
+#       should be square, and may be displayed by the window manager
+#       as small as 16x16 (but possibly larger).
+# productLogo is used as the logo at the top of the left-hand column
+#       which shows the steps to be taken. The image should be square,
+#       and is displayed at 80x80 pixels (also on HiDPI).
+# productWallpaper is an optional image, which if present, will replace
+#       the normal solid background on every page of the application.
+#       It can be any size and proportion,
+#       and will be tiled to fit the entire window.
+#       For a non-tiled wallpaper, the size should be the same as
+#       the overall window, see *windowSize* above (800x520).
+# productWelcome is shown on the welcome page of the application in
+#       the middle of the window, below the welcome text. It can be
+#       any size and proportion, and will be scaled to fit inside
+#       the window. Use `welcomeExpandingLogo` to make it non-scaled.
+#       Recommended size is 320x150.
+#
+# These filenames can also use substitutions from os-release (see above).
+images:
+    # productBanner:       "banner.png"
+    productIcon:         "logo.png"
+    productLogo:         "logo.png"
+    # productWallpaper:    "wallpaper.png"
+    productWelcome:      "logo.png"
+
+# The slideshow is displayed during execution steps (e.g. when the
+# installer is actually writing to disk and doing other slow things).
+#
+# The slideshow can be a QML file (recommended) which can display
+# arbitrary things -- text, images, animations, or even play a game --
+# during the execution step. The QML **is** abruptly stopped when the
+# execution step is done, though, so maybe a game isn't a great idea.
+#
+# The slideshow can also be a sequence of images (not recommended unless
+# you don't want QML at all in your Calamares). The images are displayed
+# at a rate of 1 every 2 seconds during the execution step.
+#
+# To configure a QML file, list a single filename:
+#   slideshow:               "show.qml"
+# To configure images, like the filenames (here, as an inline list):
+#   slideshow: [ "/etc/calamares/slideshow/0.png", "/etc/logo.png" ]
+slideshow:               "show.qml"
+
+# There are two available APIs for a QML slideshow:
+#  - 1 (the default) loads the entire slideshow when the installation-
+#      slideshow page is shown and starts the QML then. The QML
+#      is never stopped (after installation is done, times etc.
+#      continue to fire).
+#  - 2 loads the slideshow on startup and calls onActivate() and
+#      onLeave() in the root object. After the installation is done,
+#      the show is stopped (first by calling onLeave(), then destroying
+#      the QML components).
+#
+# An image slideshow does not need to have the API defined.
+slideshowAPI: 2
+
+
+# Colors for text and background components.
+#
+#  - sidebarBackground is the background of the sidebar
+#  - sidebarText is the (foreground) text color
+#  - sidebarTextHighlight sets the background of the selected (current) step.
+#    Optional, and defaults to the application palette.
+#  - sidebarSelect is the text color of the selected step.
+#
+# These colors can **also** be set through the stylesheet, if the
+# branding component also ships a stylesheet.qss. Then they are
+# the corresponding CSS attributes of #sidebarApp.
+style:
+   sidebarBackground:    "#292F34"
+   sidebarText:          "#FFFFFF"
+   sidebarTextSelect:    "#292F34"
+   sidebarTextHighlight: "#D35400"

--- a/branding/default-mobile/show.qml
+++ b/branding/default-mobile/show.qml
@@ -1,0 +1,19 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import QtQuick 2.0;
+import calamares.slideshow 1.0;
+
+Presentation
+{
+    id: presentation
+
+    Slide {
+        Image {
+            id: background
+            source: "logo.png"
+            height: 250
+            fillMode: Image.PreserveAspectFit
+            anchors.centerIn: parent
+        }
+    }
+}

--- a/branding/default-mobile/stylesheet.qss
+++ b/branding/default-mobile/stylesheet.qss
@@ -1,0 +1,92 @@
+/*
+
+A branding component can ship a stylesheet (like this one)
+which is applied to parts of the Calamares user-interface.
+In principle, all parts can be styled through CSS.
+Missing parts should be filed as issues.
+
+The IDs are based on the object names in the C++ code.
+You can use the Debug Dialog to find out object names:
+  - Open the debug dialog
+  - Choose tab *Tools*
+  - Click *Widget Tree* button
+The list of object names is printed in the log.
+
+Documentation for styling Qt Widgets through a stylesheet
+can be found at
+    https://doc.qt.io/qt-5/stylesheet-examples.html
+    https://doc.qt.io/qt-5/stylesheet-reference.html
+In Calamares, styling widget classes is supported (e.g.
+using `QComboBox` as a selector).
+
+This example stylesheet has all the actual styling commented out.
+The examples are not exhaustive.
+
+*/
+
+/*** Generic Widgets.
+ *
+ * You can style **all** widgets of a given class by selecting
+ * the class name. Some widgets have specialized sub-selectors.
+ */
+
+/*
+QPushButton { background-color: green; }
+*/
+
+/*** Main application window.
+ *
+ * The main application window has the sidebar, which in turn
+ * contains a logo and a list of items -- note that the list
+ * can **not** be styled, since it has its own custom C++
+ * delegate code.
+ */
+
+/*
+#mainApp { }
+#sidebarApp { }
+#logoApp { }
+*/
+
+/*** Welcome module.
+ *
+ * There are plenty of parts, but the buttons are the most interesting
+ * ones (donate, release notes, ...). The little icon image can be
+ * styled through *qproperty-icon*, which is a little obscure.
+ * URLs can reference the QRC paths of the Calamares application
+ * or loaded via plugins or within the filesystem. There is no
+ * comprehensive list of available icons, though.
+ */
+
+/*
+QPushButton#aboutButton { qproperty-icon: url(:/data/images/release.svg); }
+#donateButton,
+#supportButton,
+#releaseNotesButton,
+#knownIssuesButton { qproperty-icon: url(:/data/images/help.svg); }
+*/
+
+/*** Partitioning module.
+ *
+ * Many moving parts, which you will need to experiment with.
+ */
+
+/*
+#bootInfoIcon { }
+#bootInfoLable { }
+#deviceInfoIcon { }
+#defineInfoLabel { }
+#scrollAreaWidgetContents { }
+#partitionBarView { }
+*/
+
+/*** Licensing module.
+ *
+ * The licensing module paints individual widgets for each of
+ * the licenses. The item can be collapsed or expanded.
+ */
+
+/*
+#licenseItem {  }
+#licenseItemFullText {  }
+*/

--- a/modules/mobile/CMakeLists.txt
+++ b/modules/mobile/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Copyright 2020 Oliver Smith
+# SPDX-License-Identifier: GPL-3.0-or-later
+
+calamares_add_plugin( mobile
+    TYPE viewmodule
+    EXPORT_MACRO PLUGINDLLEXPORT_PRO
+    SOURCES
+        Config.cpp
+        Config.h
+        MobileQmlViewStep.cpp
+        MobileQmlViewStep.h
+        PartitionJob.cpp
+        PartitionJob.h
+        UsersJob.cpp
+        UsersJob.h
+    RESOURCES
+        mobile.qrc
+    LINK_PRIVATE_LIBRARIES
+        calamaresui
+    SHARED_LIB
+)

--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -1,0 +1,82 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#include "Config.h"
+#include <QVariant>
+
+Config::Config( QObject* parent )
+    : QObject( parent )
+{
+}
+
+QString
+cfgStr(const QVariantMap& cfgMap, QString key, QString defaultStr)
+{
+    QString ret = cfgMap.value(key).toString();
+    if ( ret.isEmpty() ) {
+	return defaultStr;
+    }
+    return ret;
+}
+
+void
+Config::setConfigurationMap( const QVariantMap& cfgMap )
+{
+    m_osName = cfgStr(cfgMap, "osName", "(unknown)");
+    m_arch = cfgStr(cfgMap, "arch", "(unknown)");
+    m_device = cfgStr(cfgMap, "device", "(unknown)");
+    m_userInterface = cfgStr(cfgMap, "userInterface", "(unknown)");
+    m_version = cfgStr(cfgMap, "version", "(unknown)");
+    m_username = cfgStr(cfgMap, "username", "user");
+
+    m_cmdLuksFormat = cfgStr(cfgMap, "cmdLuksFormat",
+	"cryptsetup luksFormat --use-random");
+    m_cmdLuksOpen = cfgStr(cfgMap, "cmdLuksOpen", "cryptsetup luksOpen");
+    m_cmdMkfsRoot = cfgStr(cfgMap, "cmdMkfsRoot", "mkfs.ext4 -L 'unknownOS_root'");
+    m_cmdMount = cfgStr(cfgMap, "cmdMount", "mount");
+    m_targetDeviceRoot = cfgStr(cfgMap, "targetDeviceRoot", "/dev/unknown");
+
+    m_cmdPasswd = cfgStr(cfgMap, "cmdPasswd", "passwd");
+    m_cmdSshdEnable = cfgStr(cfgMap, "cmdSshdEnable", "systemctl enable sshd.service");
+    m_cmdSshdDisable = cfgStr(cfgMap, "cmdSshdDisable", "systemctl disable sshd.service");
+    m_cmdSshdUseradd = cfgStr(cfgMap, "cmdSshdUseradd", "useradd -G wheel -m");
+}
+
+void
+Config::setUserPassword( const QString &userPassword )
+{
+    m_userPassword = userPassword;
+    emit userPasswordChanged( m_userPassword );
+}
+
+void
+Config::setSshdUsername( const QString &sshdUsername )
+{
+    m_sshdUsername = sshdUsername;
+    emit sshdUsernameChanged( m_sshdUsername );
+}
+
+void
+Config::setSshdPassword( const QString &sshdPassword )
+{
+    m_sshdPassword = sshdPassword;
+    emit sshdPasswordChanged( m_sshdPassword );
+}
+
+void
+Config::setIsSshEnabled( const bool isSshEnabled )
+{
+    m_isSshEnabled = isSshEnabled;
+}
+
+void
+Config::setFdePassword( const QString &fdePassword )
+{
+    m_fdePassword = fdePassword;
+    emit fdePasswordChanged( m_fdePassword );
+}
+
+void
+Config::setIsFdeEnabled( const bool isFdeEnabled )
+{
+    m_isFdeEnabled = isFdeEnabled;
+}

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -1,0 +1,133 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+#include <QObject>
+#include <memory>
+
+class Config : public QObject
+{
+    Q_OBJECT
+    /* welcome */
+    Q_PROPERTY( QString osName READ osName CONSTANT FINAL )
+    Q_PROPERTY( QString arch READ arch CONSTANT FINAL )
+    Q_PROPERTY( QString device READ device CONSTANT FINAL )
+    Q_PROPERTY( QString userInterface READ userInterface CONSTANT FINAL )
+    Q_PROPERTY( QString version READ version CONSTANT FINAL )
+
+    /* default user */
+    Q_PROPERTY( QString username READ username CONSTANT FINAL )
+    Q_PROPERTY( QString userPassword READ userPassword WRITE setUserPassword
+                NOTIFY userPasswordChanged)
+
+    /* ssh server + credentials */
+    Q_PROPERTY( QString sshdUsername READ sshdUsername WRITE setSshdUsername
+                NOTIFY sshdUsernameChanged)
+    Q_PROPERTY( QString sshdPassword READ sshdPassword WRITE setSshdPassword
+                NOTIFY sshdPasswordChanged)
+    Q_PROPERTY( bool isSshEnabled READ isSshEnabled WRITE setIsSshEnabled )
+
+    /* full disk encryption */
+    Q_PROPERTY( QString fdePassword READ fdePassword WRITE setFdePassword
+                NOTIFY fdePasswordChanged)
+    Q_PROPERTY( bool isFdeEnabled READ isFdeEnabled WRITE setIsFdeEnabled )
+
+    /* partition job */
+    Q_PROPERTY( QString cmdLuksFormat READ cmdLuksFormat CONSTANT FINAL )
+    Q_PROPERTY( QString cmdLuksOpen READ cmdLuksOpen CONSTANT FINAL )
+    Q_PROPERTY( QString cmdMkfsRoot READ cmdMkfsRoot CONSTANT FINAL )
+    Q_PROPERTY( QString cmdMount READ cmdMount CONSTANT FINAL )
+    Q_PROPERTY( QString targetDeviceRoot READ targetDeviceRoot CONSTANT FINAL )
+
+    /* users job */
+    Q_PROPERTY( QString cmdSshdEnable READ cmdSshdEnable CONSTANT FINAL )
+    Q_PROPERTY( QString cmdSshdDisable READ cmdSshdDisable CONSTANT FINAL )
+
+public:
+    Config( QObject* parent = nullptr );
+    void setConfigurationMap( const QVariantMap& );
+
+    /* welcome */
+    QString osName() const { return m_osName; }
+    QString arch() const { return m_arch; }
+    QString device() const { return m_device; }
+    QString userInterface() const { return m_userInterface; }
+    QString version() const { return m_version; }
+
+    /* default user */
+    QString username() const { return m_username; }
+    QString userPassword() const { return m_userPassword; }
+    void setUserPassword( const QString &userPassword );
+
+    /* ssh server + credetials */
+    QString sshdUsername() const { return m_sshdUsername; }
+    QString sshdPassword() const { return m_sshdPassword; }
+    bool isSshEnabled() { return m_isSshEnabled; }
+    void setSshdUsername( const QString &sshdUsername );
+    void setSshdPassword( const QString &sshdPassword );
+    void setIsSshEnabled( bool isSshEnabled );
+
+    /* full disk encryption */
+    QString fdePassword() const { return m_fdePassword; }
+    bool isFdeEnabled() { return m_isFdeEnabled; }
+    void setFdePassword( const QString &fdePassword );
+    void setIsFdeEnabled( bool isFdeEnabled );
+
+    /* partition job */
+    QString cmdLuksFormat() const { return m_cmdLuksFormat; }
+    QString cmdLuksOpen() const { return m_cmdLuksOpen; }
+    QString cmdMkfsRoot() const { return m_cmdMkfsRoot; }
+    QString cmdMount() const { return m_cmdMount; }
+    QString targetDeviceRoot() const { return m_targetDeviceRoot; }
+
+    /* users job */
+    QString cmdPasswd() const { return m_cmdPasswd; }
+    QString cmdSshdEnable() const { return m_cmdSshdEnable; }
+    QString cmdSshdDisable() const { return m_cmdSshdDisable; }
+    QString cmdSshdUseradd() const { return m_cmdSshdUseradd; }
+
+private:
+    /* welcome */
+    QString m_osName;
+    QString m_arch;
+    QString m_device;
+    QString m_userInterface;
+    QString m_version;
+
+    /* default user */
+    QString m_username;
+    QString m_userPassword;
+
+    /* ssh server + credetials */
+    QString m_sshdUsername;
+    QString m_sshdPassword;
+    bool m_isSshEnabled;
+
+    /* full disk encryption */
+    QString m_fdePassword = "";
+    bool m_isFdeEnabled = false;
+
+    /* partition job */
+    QString m_cmdLuksFormat;
+    QString m_cmdLuksOpen;
+    QString m_cmdMkfsRoot;
+    QString m_cmdMount;
+    QString m_targetDeviceRoot;
+
+    /* users job */
+    QString m_cmdPasswd;
+    QString m_cmdSshdEnable;
+    QString m_cmdSshdDisable;
+    QString m_cmdSshdUseradd;
+
+signals:
+    /* default user */
+    void userPasswordChanged ( QString userPassword );
+
+    /* ssh server + credetials */
+    void sshdUsernameChanged ( QString sshdUsername );
+    void sshdPasswordChanged ( QString sshdPassword );
+    /* isSshEnabled doesn't need a signal, we don't read it from QML */
+
+    /* full disk encryption */
+    void fdePasswordChanged ( QString fdePassword );
+};

--- a/modules/mobile/MobileQmlViewStep.cpp
+++ b/modules/mobile/MobileQmlViewStep.cpp
@@ -1,0 +1,105 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#include "MobileQmlViewStep.h"
+#include "PartitionJob.h"
+#include "UsersJob.h"
+
+#include "GlobalStorage.h"
+#include "JobQueue.h"
+
+#include "locale/LabelModel.h"
+#include "utils/Dirs.h"
+#include "utils/Logger.h"
+#include "utils/Variant.h"
+
+#include "Branding.h"
+#include "modulesystem/ModuleManager.h"
+
+#include <QProcess>
+
+CALAMARES_PLUGIN_FACTORY_DEFINITION( MobileQmlViewStepFactory, registerPlugin< MobileQmlViewStep >(); )
+
+void
+MobileQmlViewStep::setConfigurationMap( const QVariantMap& configurationMap )
+{
+    m_config->setConfigurationMap( configurationMap );
+    Calamares::QmlViewStep::setConfigurationMap( configurationMap );
+}
+
+MobileQmlViewStep::MobileQmlViewStep( QObject* parent )
+    : Calamares::QmlViewStep( parent )
+    , m_config( new Config( this ) )
+{
+}
+
+void
+MobileQmlViewStep::onLeave()
+{
+    Calamares::Job *partition, *users;
+
+    /* HACK: run partition job now */
+    partition = new PartitionJob( m_config->cmdLuksFormat(),
+                                  m_config->cmdLuksOpen(),
+                                  m_config->cmdMkfsRoot(),
+                                  m_config->cmdMount(),
+                                  m_config->targetDeviceRoot(),
+                                  m_config->isFdeEnabled(),
+                                  m_config->fdePassword() );
+    Calamares::JobResult res = partition->exec();
+    if ( !res )
+        cError() << "PARTITION JOB FAILED: " << res.message();
+
+    /* Put users job in queue (should run after unpackfs) */
+    m_jobs.clear();
+    QString cmdSshd = m_config->isSshEnabled()
+        ? m_config->cmdSshdEnable()
+        : m_config->cmdSshdDisable();
+    users = new UsersJob( m_config->cmdPasswd(),
+                          cmdSshd,
+                          m_config->cmdSshdUseradd(),
+                          m_config->isSshEnabled(),
+                          m_config->username(),
+                          m_config->userPassword(),
+                          m_config->sshdUsername(),
+                          m_config->sshdPassword() );
+    m_jobs.append( Calamares::job_ptr( users ) );
+}
+
+bool
+MobileQmlViewStep::isNextEnabled() const
+{
+    return false;
+}
+
+bool
+MobileQmlViewStep::isBackEnabled() const
+{
+    return false;
+}
+
+
+bool
+MobileQmlViewStep::isAtBeginning() const
+{
+    return true;
+}
+
+
+bool
+MobileQmlViewStep::isAtEnd() const
+{
+    return true;
+}
+
+
+Calamares::JobList
+MobileQmlViewStep::jobs() const
+{
+    return m_jobs;
+}
+
+QObject*
+MobileQmlViewStep::getConfig()
+{
+    return m_config;
+}

--- a/modules/mobile/MobileQmlViewStep.h
+++ b/modules/mobile/MobileQmlViewStep.h
@@ -1,0 +1,40 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#ifndef PARTITION_QMLVIEWSTEP_H
+#define PARTITION_QMLVIEWSTEP_H
+#include "Config.h"
+
+#include "utils/PluginFactory.h"
+#include "viewpages/QmlViewStep.h"
+
+#include <DllMacro.h>
+
+#include <QObject>
+#include <QVariantMap>
+
+class PLUGINDLLEXPORT MobileQmlViewStep : public Calamares::QmlViewStep
+{
+    Q_OBJECT
+
+public:
+    explicit MobileQmlViewStep( QObject* parent = nullptr );
+
+    bool isNextEnabled() const override;
+    bool isBackEnabled() const override;
+    bool isAtBeginning() const override;
+    bool isAtEnd() const override;
+
+    Calamares::JobList jobs() const override;
+
+    void setConfigurationMap( const QVariantMap& configurationMap ) override;
+    void onLeave();
+    QObject* getConfig() override;
+
+private:
+    Config* m_config;
+    QList< Calamares::job_ptr > m_jobs;
+};
+
+CALAMARES_PLUGIN_FACTORY_DECLARATION( MobileQmlViewStepFactory )
+
+#endif  // PARTITION_QMLVIEWSTEP_H

--- a/modules/mobile/PartitionJob.cpp
+++ b/modules/mobile/PartitionJob.cpp
@@ -1,0 +1,114 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#include "PartitionJob.h"
+
+#include "GlobalStorage.h"
+#include "JobQueue.h"
+#include "Settings.h"
+#include "utils/CalamaresUtilsSystem.h"
+#include "utils/Logger.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+
+PartitionJob::PartitionJob( QString cmdLuksFormat, QString cmdLuksOpen,
+                            QString cmdMkfsRoot, QString cmdMount,
+                            QString targetDeviceRoot,
+                            bool isFdeEnabled, const QString& password )
+    : Calamares::Job()
+    , m_cmdLuksFormat (cmdLuksFormat)
+    , m_cmdLuksOpen (cmdLuksOpen)
+    , m_cmdMkfsRoot (cmdMkfsRoot)
+    , m_cmdMount (cmdMount)
+    , m_targetDeviceRoot (targetDeviceRoot)
+    , m_isFdeEnabled (isFdeEnabled)
+    , m_password (password)
+{
+}
+
+
+QString
+PartitionJob::prettyName() const
+{
+    return "Creating and formatting installation partition";
+}
+
+/* Fill the "global storage", so the following jobs (like unsquashfs) work.
+   The code is similar to modules/partition/jobs/FillGlobalStorageJob.cpp in
+   Calamares. */
+void
+FillGlobalStorage(const QString device, const QString pathMount)
+{
+    using namespace Calamares;
+
+    GlobalStorage* gs = JobQueue::instance()->globalStorage();
+    QVariantList partitions;
+    QVariantMap partition;
+
+    /* See mapForPartition() in FillGlobalStorageJob.cpp */
+    partition[ "device"] = device;
+    partition[ "mountPoint" ] = "/";
+    partition[ "claimed" ] = true;
+
+    /* Ignored by calamares modules used in combination with the "mobile"
+     * module, so we can get away with leaving them empty for now. */
+    partition[ "uuid" ] = "";
+    partition[ "fsName" ] = "";
+    partition[ "fs" ] = "";
+
+    partitions << partition;
+    gs->insert( "partitions", partitions);
+    gs->insert( "rootMountPoint", pathMount);
+}
+
+Calamares::JobResult
+PartitionJob::exec()
+{
+    using namespace Calamares;
+    using namespace CalamaresUtils;
+    using namespace std;
+
+    const QString pathMount = "/mnt/install";
+    const QString cryptName = "calamares_crypt";
+    QString cryptDev = "/dev/mapper/" + cryptName;
+    QString passwordStdin = m_password + "\n";
+    QString dev = m_targetDeviceRoot;
+
+    QList< QPair<const QStringList, const QString> > commands = {
+        {{"mkdir", "-p", pathMount}, nullptr},
+    };
+
+    if ( m_isFdeEnabled ) {
+        commands.append({
+            {{"sh", "-c", m_cmdLuksFormat + " " + dev}, passwordStdin},
+            {{"sh", "-c", m_cmdLuksOpen + " " + dev + " " + cryptName}, passwordStdin},
+            {{"sh", "-c", m_cmdMkfsRoot + " " + cryptDev}, nullptr},
+            {{"sh", "-c", m_cmdMount + " " + cryptDev + " " + pathMount}, nullptr},
+        });
+    } else {
+        commands.append({
+            {{"sh", "-c", m_cmdMkfsRoot + " " + dev}, nullptr},
+            {{"sh", "-c", m_cmdMount + " " + dev + " " + pathMount}, nullptr}
+        });
+    }
+
+    foreach( auto command, commands ) {
+        const QStringList args = command.first;
+        const QString stdInput = command.second;
+        const QString pathRoot = "/";
+
+        ProcessResult res = System::runCommand( System::RunLocation::RunInHost,
+                                                args, pathRoot, stdInput,
+                                                chrono::seconds( 120 ) );
+        if ( res.getExitCode() ) {
+            return JobResult::error( "Command failed:<br><br>"
+                                     "'" + args.join(" ") + "'<br><br>"
+                                     " with output:<br><br>"
+                                     "'" + res.getOutput() + "'");
+        }
+    }
+
+    FillGlobalStorage(m_isFdeEnabled ? cryptDev : dev, pathMount);
+    return JobResult::ok();
+}

--- a/modules/mobile/PartitionJob.h
+++ b/modules/mobile/PartitionJob.h
@@ -1,0 +1,29 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+#include "Job.h"
+
+
+class PartitionJob : public Calamares::Job
+{
+    Q_OBJECT
+public:
+    PartitionJob( QString cmdLuksFormat, QString cmdLuksOpen,
+                  QString cmdMkfsRoot, QString cmdMount,
+                  QString targetDeviceRoot,
+                  bool isFdeEnabled, const QString& password );
+
+    QString prettyName() const override;
+    Calamares::JobResult exec() override;
+
+    Calamares::JobList createJobs();
+
+private:
+    QString m_cmdLuksFormat;
+    QString m_cmdLuksOpen;
+    QString m_cmdMkfsRoot;
+    QString m_cmdMount;
+    QString m_targetDeviceRoot;
+    bool m_isFdeEnabled;
+    QString m_password;
+};

--- a/modules/mobile/UsersJob.cpp
+++ b/modules/mobile/UsersJob.cpp
@@ -1,0 +1,75 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#include "UsersJob.h"
+
+#include "GlobalStorage.h"
+#include "JobQueue.h"
+#include "Settings.h"
+#include "utils/CalamaresUtilsSystem.h"
+#include "utils/Logger.h"
+
+#include <QDir>
+#include <QFileInfo>
+
+
+UsersJob::UsersJob( QString cmdPasswd, QString cmdSshd, QString cmdSshdUseradd,
+                    bool isSshEnabled,
+                    QString username, QString password,
+                    QString sshdUsername, QString sshdPassword )
+    : Calamares::Job()
+    , m_cmdPasswd (cmdPasswd)
+    , m_cmdSshd (cmdSshd)
+    , m_cmdSshdUseradd (cmdSshdUseradd)
+    , m_isSshEnabled (isSshEnabled)
+    , m_username (username)
+    , m_password (password)
+    , m_sshdUsername (sshdUsername)
+    , m_sshdPassword (sshdPassword)
+{
+}
+
+
+QString
+UsersJob::prettyName() const
+{
+    return "Configuring users";
+}
+
+Calamares::JobResult
+UsersJob::exec()
+{
+    using namespace Calamares;
+    using namespace CalamaresUtils;
+    using namespace std;
+
+    QList< QPair<const QStringList, const QString> > commands = {
+        { {"sh", "-c", m_cmdPasswd + " " + m_username}, m_password + "\n" + m_password + "\n" },
+        { {"sh", "-c", m_cmdSshd}, nullptr},
+    };
+
+    if (m_isSshEnabled) {
+        commands.append({{"sh", "-c", m_cmdSshdUseradd + " " + m_sshdUsername},
+                         nullptr});
+        commands.append({{"sh", "-c", m_cmdPasswd + " " + m_sshdUsername},
+                         m_sshdPassword + "\n" + m_sshdPassword + "\n"});
+    }
+
+    foreach( auto command, commands ) {
+        auto location = System::RunLocation::RunInTarget;
+        const QString pathRoot = "/";
+        const QStringList args = command.first;
+        const QString stdInput = command.second;
+
+        ProcessResult res = System::runCommand( location, args, pathRoot,
+                                                stdInput,
+                                                chrono::seconds( 30 ));
+        if ( res.getExitCode() ) {
+            return JobResult::error( "Command failed:<br><br>"
+                                     "'" + args.join(" ") + "'<br><br>"
+                                     " with output:<br><br>"
+                                     "'" + res.getOutput() + "'");
+        }
+    }
+
+    return JobResult::ok();
+}

--- a/modules/mobile/UsersJob.h
+++ b/modules/mobile/UsersJob.h
@@ -1,0 +1,30 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+#pragma once
+#include "Job.h"
+
+
+class UsersJob : public Calamares::Job
+{
+    Q_OBJECT
+public:
+    UsersJob( QString cmdPasswd, QString cmdSshd, QString cmdSshdUseradd,
+              bool isSshEnabled,
+              QString username, QString password,
+              QString sshdUsername, QString sshdPassword );
+
+    QString prettyName() const override;
+    Calamares::JobResult exec() override;
+
+    Calamares::JobList createJobs();
+
+private:
+    QString m_cmdPasswd;
+    QString m_cmdSshd;
+    QString m_cmdSshdUseradd;
+    bool m_isSshEnabled;
+    QString m_username;
+    QString m_password;
+    QString m_sshdUsername;
+    QString m_sshdPassword;
+};

--- a/modules/mobile/default_pin.qml
+++ b/modules/mobile/default_pin.qml
@@ -1,0 +1,95 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    Text {
+        id: description
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: 30
+        wrapMode: Text.WordWrap
+
+        text: "Set the numeric password of your user. The lockscreen will" +
+              " ask for this PIN. This is <i>not</i> the PIN of your SIM" +
+              " card. Make sure to remember it."
+
+        width: 500
+    }
+
+    TextField {
+        id: userPin
+        anchors.top: description.bottom
+        placeholderText: qsTr("PIN")
+        echoMode: TextInput.Password
+        onTextChanged: validatePin(userPin, userPinRepeat, errorText)
+        text: config.userPassword
+
+        /* Let the virtual keyboard change to digits only */
+        inputMethodHints: Qt.ImhDigitsOnly
+        onActiveFocusChanged: {
+            if(activeFocus) {
+                Qt.inputMethod.update(Qt.ImQueryInput)
+            }
+        }
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    TextField {
+        id: userPinRepeat
+        anchors.top: userPin.bottom
+        placeholderText: qsTr("PIN (repeat)")
+        inputMethodHints: Qt.ImhDigitsOnly
+        echoMode: TextInput.Password
+        onTextChanged: validatePin(userPin, userPinRepeat, errorText)
+        text: config.userPassword
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Text {
+        anchors.top: userPinRepeat.bottom
+        id: errorText
+        visible: false
+        wrapMode: Text.WordWrap
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Button {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: errorText.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Continue")
+        onClicked: {
+            if (validatePin(userPin, userPinRepeat, errorText)) {
+                config.userPassword = userPin.text;
+                navTo("ssh_confirm");
+            }
+        }
+    }
+}

--- a/modules/mobile/fde_confirm.qml
+++ b/modules/mobile/fde_confirm.qml
@@ -1,0 +1,65 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    Text {
+        id: welcomeText
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: 30
+        wrapMode: Text.WordWrap
+
+        text: "To protect your data in case your device gets stolen," +
+              " it is recommended to enable full disk encryption.<br>" +
+              "<br>" +
+              "If you enable full disk encryption, you will be asked for" +
+              " a password. Without this password, it is not possible to" +
+              " boot your device or access any data on it. Make sure that" +
+              " you don't lose this password!"
+
+        width: 500
+    }
+
+    Button {
+        id: enableButton
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: welcomeText.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Enable")
+        onClicked: {
+            config.isFdeEnabled = true;
+            navTo("fde_pass");
+        }
+    }
+
+    Button {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: enableButton.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Disable")
+        onClicked: {
+            config.isFdeEnabled = false;
+            navTo("install_confirm");
+        }
+    }
+}

--- a/modules/mobile/fde_pass.qml
+++ b/modules/mobile/fde_pass.qml
@@ -1,0 +1,80 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    TextField {
+        id: password
+        anchors.top: parent.top
+        placeholderText: qsTr("Password")
+        inputMethodHints: Qt.ImhPreferLowercase
+        echoMode: TextInput.Password
+        onTextChanged: validatePassword(password, passwordRepeat,
+                                        errorText)
+        text: config.fdePassword
+
+        onActiveFocusChanged: {
+            if(activeFocus) {
+                Qt.inputMethod.update(Qt.ImQueryInput);
+            }
+        }
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    TextField {
+        id: passwordRepeat
+        anchors.top: password.bottom
+        placeholderText: qsTr("Password (repeat)")
+        echoMode: TextInput.Password
+        onTextChanged: validatePassword(password, passwordRepeat,
+                                        errorText)
+        text: config.fdePassword
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Text {
+        id: errorText
+        anchors.top: passwordRepeat.bottom
+        visible: false
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+        wrapMode: Text.WordWrap
+    }
+    Button {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: errorText.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Continue")
+        onClicked: {
+            if (validatePassword(password, passwordRepeat, errorText)) {
+                config.fdePassword = password.text;
+                navTo("install_confirm");
+            }
+        }
+    }
+}

--- a/modules/mobile/install_confirm.qml
+++ b/modules/mobile/install_confirm.qml
@@ -1,0 +1,46 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    Text {
+        id: welcomeText
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: 30
+        wrapMode: Text.WordWrap
+
+        text: "Once you hit 'install', the installation will begin. It will" +
+              " typically take a few minutes. Do not power off the device" +
+              " until it is done. Afterwards, it will reboot into the" +
+              " installed system."
+
+        width: 500
+    }
+
+    Button {
+        id: enableButton
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: welcomeText.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Install")
+        onClicked: navFinish()
+    }
+}

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -1,0 +1,70 @@
+# Commented out values are defaults.
+# All commands are running with 'sh -c'.
+---
+#######
+### Target OS information
+#######
+
+## Operating System Name
+# osName: "(unknown)"
+
+## User Interface name (e.g. Plasma Mobile)
+# userInterface: "(unknown)"
+
+## OS version
+# version: "(unknown)"
+
+## Default username (for which the password will be set)
+# username: "user"
+
+#######
+### Target device information
+#######
+
+## Architecture (e.g. aarch64)
+# arch: "(unknown)"
+
+## Name of the device (e.g. PinePhone)
+# device: "(unknown)"
+
+## Partition that will be formatted and mounted (optionally with FDE) for the rootfs
+# targetDeviceRoot: "/dev/unknown"
+
+#######
+### Commands running in the installer OS
+#######
+
+## Format the target partition with LUKS
+## Arguments: <device>
+## Stdin: password with \n
+# cmdLuksFormat: "cryptsetup luksFormat --use-random"
+
+## Open the formatted partition
+## Arguments: <device> <mapping name>
+## Stdin: password with \n
+# cmdLuksOpen: "cryptsetup luksOpen"
+
+## Format the rootfs with a file system
+## Arguments: <device>
+# cmdMkfsRoot: "mkfs.ext4 -L 'unknownOS_root'"
+
+## Mount the partition after formatting with file system
+## Arguments: <device> <mountpoint>
+# cmdMount: "mount"
+
+#######
+### Commands running in the target OS (chroot)
+#######
+
+## Set the password for default user and sshd user
+## Arguments: <username>
+## Stdin: password twice, each time with \n
+# cmdPasswd: "passwd"
+
+## Enable or disable sshd
+# cmdSshdEnable: "systemctl enable sshd.service"
+# cmdSshdDisable: "systemctl disable sshd.service"
+
+## Create the user for sshd
+## Arguments: <username>
+# cmdSshdUseradd: "useradd -G wheel -m"

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -1,0 +1,321 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Page
+{
+    property var screen: "welcome"
+    property var screenPrevious: []
+    property var titles: {
+        "welcome": null, /* titlebar disabled */
+        "default_pin": "Lockscreen PIN",
+        "ssh_confirm": "SSH server",
+        "ssh_credentials": "SSH credentials",
+        "fde_confirm": "Full disk encryption",
+        "fde_pass": "Full disk encryption",
+        "install_confirm": "Ready to install",
+        "wait": null
+    }
+    /* Only allow characters, that can be typed in with the initramfs on-screen keyboard
+     * (osk-sdl: see src/keyboard.cpp). FIXME: make configurable, but keep this as default? */
+     property var allowed_chars:
+        /* layer 0 */ "abcdefghijklmnopqrstuvwxyz" +
+        /* layer 1 */ "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
+        /* layer 2 */ "1234567890" + "@#$%&-_+()" + ",\"':;!?" +
+        /* layer 3 */ "~`|·√πτ÷×¶" + "©®£€¥^°*{}" + "\\/<>=[]" +
+        /* bottom row */ " ."
+
+    Item {
+        id: appContainer
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.right: parent.right
+        anchors.bottom: inputPanel.top
+        Item {
+            width: parent.width
+            height: parent.height
+
+            Rectangle {
+                id: mobileNavigation
+                width: parent.width
+                height: 60
+                color: "#e6e4e1"
+                Layout.fillWidth: true
+
+                border.width: 1
+                border.color: "#a7a7a7"
+
+                anchors.left: parent.left
+                anchors.right: parent.right
+
+                RowLayout {
+                    width: parent.width
+                    height: parent.height
+                    spacing: 6
+
+                    Button {
+                        Layout.leftMargin: 6
+                        id: mobileBack
+                        text: "<"
+
+                        background: Rectangle {
+                            implicitWidth: 32
+                            implicitHeight: 30
+                            border.color: "#c1bab5"
+                            border.width: 1
+                            radius: 4
+                            color: mobileBack.down ? "#dbdbdb" : "#f2f2f2"
+                        }
+
+                        onClicked: navBack()
+                    }
+                    Rectangle {
+                        implicitHeight: 30
+                        Layout.fillWidth: true
+                        color: "#e6e4e1"
+
+                        Text {
+                            id: mobileTitle
+                            text: ""
+                            color: "#303638"
+                            anchors.verticalCenter: parent.verticalCenter
+                            anchors.horizontalCenter: parent.horizontalCenter
+                        }
+                    }
+                    Rectangle {
+                        color: "#e6e4e1"
+                        Layout.rightMargin: 6
+                        implicitWidth: 32
+                        implicitHeight: 30
+                        id: filler
+                    }
+                }
+            }
+
+            Loader {
+                id: load
+                anchors.left: parent.left
+                anchors.top: mobileNavigation.bottom
+                anchors.right: parent.right
+            }
+        }
+    }
+    InputPanel {
+        id: inputPanel
+        y: Qt.inputMethod.visible ? parent.height - inputPanel.height : parent.height
+        anchors.left: parent.left
+        anchors.right: parent.right
+    }
+
+    Timer {
+        id: timer
+    }
+
+    /* Navigation related */
+    function navTo(name, historyPush=true) {
+        if (historyPush)
+            screenPrevious.push(screen);
+        screen = name;
+        load.source = name + ".qml";
+        mobileNavigation.visible = (titles[name] !== null);
+        mobileTitle.text = "<b>" + titles[name] + "</b>";
+        Qt.inputMethod.hide();
+    }
+    function navFinish() {
+        /* Show a waiting screen and wait a second (so it can render), then let
+         * MobileQmlViewStep.cpp::onLeave() create the (encrypted) partition
+         * and mount it. We can't have this as proper job due to ondev#18. */
+        navTo("wait");
+        timer.interval = 1000;
+        timer.repeat = false;
+        timer.triggered.connect(ViewManager.next);
+        timer.start();
+    }
+    function navBack() {
+        if (screenPrevious.length)
+            return navTo(screenPrevious.pop(), false);
+        ViewManager.back();
+    }
+    function onActivate() {
+        navTo(screen, false);
+    }
+
+    /* Input validation: show/clear failures */
+    function validationFailure(errorText, message="") {
+        errorText.text = message;
+        errorText.visible = true;
+        return false;
+    }
+    function validationFailureClear(errorText) {
+        errorText.text = "";
+        errorText.visible = false;
+        return true;
+    }
+
+    /* Input validation: user-screens (default_pin, ssh_credentials) */
+    function validatePin(userPin, userPinRepeat, errorText) {
+        var pin = userPin.text;
+        var repeat = userPinRepeat.text;
+
+        if (pin == "")
+            return validationFailure(errorText);
+
+        if (!pin.match(/^[0-9]*$/))
+            return validationFailure(errorText,
+                                     "Only digits are allowed.");
+
+        if (pin.length < 5)
+            return validationFailure(errorText,
+                                     "Too short: needs at least 5 digits.");
+
+        if (repeat == "")
+            return validationFailure(errorText);
+
+        if (repeat != pin)
+            return validationFailure(errorText,
+                                     "The PINs don't match.");
+                             
+        return validationFailureClear(errorText);
+    }
+    function validateSshdUsername(username, errorText) {
+        var name = username.text;
+        var reserved = [ /* FIXME: make configurable */
+            config.username,
+            "adm",
+            "at ",
+            "bin",
+            "colord",
+            "cron",
+            "cyrus",
+            "daemon",
+            "ftp",
+            "games",
+            "geoclue",
+            "guest",
+            "halt",
+            "lightdm",
+            "lp",
+            "mail",
+            "man",
+            "messagebus",
+            "news",
+            "nobody",
+            "ntp",
+            "operator",
+            "polkitd",
+            "postmaster",
+            "pulse",
+            "root",
+            "shutdown",
+            "smmsp",
+            "squid",
+            "sshd",
+            "sync",
+            "uucp",
+            "vpopmail",
+            "xfs",
+        ]
+
+        /* Validate characters */
+        for (var i=0; i<name.length; i++) {
+            if (i) {
+                if (!name[i].match(/^[a-z0-9_-]$/))
+                    return validationFailure(errorText,
+                                             "Characters must be lowercase" +
+                                             " letters, numbers,<br>" +
+                                             " underscores or minus signs.");
+            } else {
+                if (!name[i].match(/^[a-z_]$/))
+                    return validationFailure(errorText,
+                                             "First character must be a" +
+                                             " lowercase letter or an" +
+                                             " underscore.");
+            }
+        }
+
+        /* Validate against reserved usernames */
+        for (var i=0;i<reserved.length;i++) {
+            if (name == reserved[i])
+                return validationFailure(errorText, "Username '" +
+                                                    reserved[i] +
+                                                    "' is reserved.")
+        }
+
+        /* Passed */
+        return validationFailureClear(errorText);
+    }
+    function validateSshdPassword(password, passwordRepeat, errorText) {
+        var pass = password.text;
+        var repeat = passwordRepeat.text;
+
+        if (pass == "")
+            return validationFailure(errorText);
+
+        if (pass.length < 8)
+            return validationFailure(errorText,
+                                     "Too short: needs at least 8" +
+                                     " characters.");
+
+        if (repeat == "")
+            return validationFailure(errorText);
+
+        if (pass != repeat)
+            return validationFailure(errorText, "Passwords don't match.");
+
+        return validationFailureClear(errorText);
+    }
+
+    /* Input validation: fde_pass */
+    function check_chars(input) {
+        for (var i = 0; i < input.length; i++) {
+            if (allowed_chars.indexOf(input[i]) == -1)
+                return false;
+        }
+        return true;
+    }
+    function allowed_chars_multiline() {
+        /* return allowed_chars split across multiple lines */
+        var step = 20;
+        var ret = "";
+        for (var i = 0; i < allowed_chars.length + step; i += step)
+            ret += allowed_chars.slice(i, i + step) + "\n";
+        return ret.trim();
+    }
+    function validatePassword(password, passwordRepeat, errorText) {
+        var pass = password.text;
+        var repeat = passwordRepeat.text;
+
+        if (pass == "")
+            return validationFailure(errorText);
+
+        if (!check_chars(pass))
+            return validationFailure(errorText,
+                                     "The password must only contain" +
+                                     " these characters, others cannot be" +
+                                     " typed in at boot time:\n" +
+                                     "\n" +
+                                     allowed_chars_multiline());
+
+        if (pass.length < 8)
+            return validationFailure(errorText,
+                                     "Too short: needs at least 8" +
+                                     " characters.");
+
+        if (repeat == "")
+            return validationFailure(errorText);
+
+        if (pass != repeat)
+            return validationFailure(errorText, "Passwords don't match.");
+
+        return validationFailureClear(errorText);
+    }
+}

--- a/modules/mobile/mobile.qrc
+++ b/modules/mobile/mobile.qrc
@@ -1,0 +1,17 @@
+<!DOCTYPE RCC><RCC version="1.0">
+<qresource>
+  <file>mobile.qml</file>
+
+  <file>welcome.qml</file>
+
+  <file>default_pin.qml</file> <!-- default user: pin -->
+  <file>ssh_confirm.qml</file> <!-- sshd: enable or not? -->
+  <file>ssh_credentials.qml</file> <!-- sshd user: username, password -->
+
+  <file>fde_confirm.qml</file> <!-- enable FDE or not? -->
+  <file>fde_pass.qml</file> <!-- FDE password (optional) -->
+  <file>install_confirm.qml</file> <!-- final confirmation before install -->
+
+  <file>wait.qml</file> <!-- please wait while partitioning -->
+</qresource>
+</RCC>

--- a/modules/mobile/ssh_confirm.qml
+++ b/modules/mobile/ssh_confirm.qml
@@ -1,0 +1,68 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    Text {
+        id: welcomeText
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: parent.top
+        anchors.topMargin: 30
+        wrapMode: Text.WordWrap
+
+        text: "If you don't know what SSH is, choose 'disable'.<br>" +
+              "<br>" +
+              "With 'enable', you will be asked for a second username and" +
+              " password. You will be able to login to the SSH server with" +
+              " these credentials via USB (172.16.42.1), Wi-Fi and possibly" +
+              " cellular network. It is recommended to replace the password" +
+              " with an SSH key after the installation.<br>" +
+              "<br>" +
+              "More information:<br>" +
+              "https://postmarketos.org/ssh"
+
+        width: 500
+    }
+
+    Button {
+        id: enableButton
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: welcomeText.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Enable")
+        onClicked: {
+            config.isSshEnabled = true;
+            navTo("ssh_credentials");
+        }
+    }
+
+    Button {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: enableButton.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Disable")
+        onClicked: {
+            config.isSshEnabled = false;
+            navTo("fde_confirm");
+        }
+    }
+}

--- a/modules/mobile/ssh_credentials.qml
+++ b/modules/mobile/ssh_credentials.qml
@@ -1,0 +1,107 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Item {
+    anchors.left: parent.left
+    anchors.top: parent.top
+    anchors.right: parent.right
+    width: parent.width
+    height: parent.height
+
+    TextField {
+        id: username
+        anchors.top: parent.top
+        placeholderText: qsTr("SSH username")
+        inputMethodHints: Qt.ImhPreferLowercase
+        onTextChanged: validateSshdUsername(username, errorTextUsername)
+        text: config.sshdUsername
+
+        onActiveFocusChanged: {
+            if(activeFocus) {
+                Qt.inputMethod.update(Qt.ImQueryInput);
+            }
+        }
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Text {
+        id: errorTextUsername
+        anchors.top: username.bottom
+        visible: false
+        wrapMode: Text.WordWrap
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    TextField {
+        id: password
+        anchors.top: errorTextUsername.bottom
+        placeholderText: qsTr("SSH password")
+        echoMode: TextInput.Password
+        onTextChanged: validateSshdPassword(password, passwordRepeat,
+                                           errorTextPassword)
+        text: config.sshdPassword
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    TextField {
+        id: passwordRepeat
+        anchors.top: password.bottom
+        placeholderText: qsTr("SSH password (repeat)")
+        echoMode: TextInput.Password
+        onTextChanged: validateSshdPassword(password, passwordRepeat,
+                                           errorTextPassword)
+        text: config.sshdPassword
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Text {
+        id: errorTextPassword
+        anchors.top: passwordRepeat.bottom
+        visible: false
+        wrapMode: Text.WordWrap
+
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+    Button {
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: errorTextPassword.bottom
+        anchors.topMargin: 40
+        width: 500
+
+        text: qsTr("Continue")
+        onClicked: {
+            if (validateSshdUsername(username, errorTextUsername) &&
+                validateSshdPassword(password, passwordRepeat,
+                                    errorTextPassword)) {
+                config.sshdUsername = username.text;
+                config.sshdPassword = password.text;
+
+                navTo("fde_confirm");
+            }
+        }
+    }
+}

--- a/modules/mobile/wait.qml
+++ b/modules/mobile/wait.qml
@@ -1,0 +1,45 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Page
+{
+    id: fdeWait
+
+    Item {
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.right: parent.right
+        width: parent.width
+        height: parent.height
+
+        Image {
+            id: logo
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: parent.top
+            anchors.topMargin: 50
+            height: 250
+            fillMode: Image.PreserveAspectFit
+            source: "file:///usr/share/calamares/branding/default-mobile/logo.png"
+        }
+        Text {
+            id: waitText
+            anchors.horizontalCenter: parent.horizontalCenter
+            anchors.top: logo.bottom
+            anchors.topMargin: 150
+            wrapMode: Text.WordWrap
+            text: "Formatting and mounting target partition. This may" +
+                  " take up to 20 seconds, please be patient."
+            width: 500
+        }
+    }
+}

--- a/modules/mobile/welcome.qml
+++ b/modules/mobile/welcome.qml
@@ -1,0 +1,65 @@
+/* Copyright 2020 Oliver Smith
+ * SPDX-License-Identifier: GPL-3.0-or-later */
+import io.calamares.core 1.0
+import io.calamares.ui 1.0
+
+import QtQuick 2.10
+import QtQuick.Controls 2.10
+import QtQuick.Layouts 1.3
+import org.kde.kirigami 2.7 as Kirigami
+import QtGraphicalEffects 1.0
+import QtQuick.Window 2.3
+import QtQuick.VirtualKeyboard 2.1
+
+Page
+{
+    id: welcome
+
+    Item {
+        id: appContainer
+        anchors.left: parent.left
+        anchors.top: parent.top
+        anchors.right: parent.right
+        Item {
+            width: parent.width
+            height: parent.height
+
+            Image {
+                id: logo
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: parent.top
+                anchors.topMargin: 50
+                height: 250
+                fillMode: Image.PreserveAspectFit
+                source: "file:///usr/share/calamares/branding/default-mobile/logo.png"
+            }
+            Text {
+                id: welcomeText
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: logo.bottom
+                anchors.topMargin: 50
+                horizontalAlignment: Text.AlignRight
+                text: "You are about to install<br>" +
+                      "<b>" + config.osName +
+                      " " + config.version + "</b><br>" +
+                      "user interface " +
+                      "<b>" + config.userInterface + "</b><br>" +
+                      "architecture " +
+                      "<b>" + config.arch + "</b><br>" +
+                      "on your " +
+                      "<b>" + config.device + "</b><br>"
+                width: 500
+            }
+
+            Button {
+                anchors.horizontalCenter: parent.horizontalCenter
+                anchors.top: welcomeText.bottom
+                anchors.topMargin: 50
+                width: 500
+
+                text: qsTr("Continue")
+                onClicked: navTo("default_pin")
+            }
+        }
+    }
+}


### PR DESCRIPTION
Create a new module and branding targeted at the smartphone and tablet
use case. The installation process is significantly different from your
typical PC install:
* The UI must fit mobile screens, the amount of inputs visible on one
  screen must be reduced.
* Every input must be controllable with an on screen keyboard.
* Full disk encryption is done with GRUB in Calamares, but mobile
  devices use other bootloaders (u-boot, lk).
* Complex partitioning screens are not useful for most users, as the
  expectation is not that multiple OS can be installed next to each
  other.

It would be nice if the regular Calamares modules worked with mobile
devices eventually. But this can't be done in one step (and before that,
the QML <> QWidgets related refactoring should probably be completed?),
therefore let's add it to calamares-extensions first.

This initial version is far from perfect, but what is there works
reliably. It should give a good shared base to iterate upon.

Implemented screens:
* Welcome
* Lockscreen PIN
  Set the user password, but as numeric PIN. Because that is what the
  current generation of mobile friendly Linux DEs expects (Plasma Mobile
  and Phosh).
* SSH server: enable or disable
  To debug Linux distributions on phones, SSH is essential. Give
  advanced users the opportunity to enable it and casual users the
  option to skip this.
* Credentials for SSH server
  The SSH server has a dedicated user account with a stronger password.
  Users are encouraged to replace password auth with SSH key auth after
  the installation.
* Full disk encryption: enable or disable
* Full disk encryption password

Screenshots:
https://postmarketos.org/blog/2020/07/15/pinephone-ce-preorder/#installer-with-optional-ssh-server-and-encryption

There is no partitioning screen. The target partition, which will be
formatted and optionally encrypted is defined in mobile.conf as
targetDeviceRoot. It is expected that the installer OS will use this to
install to an empty partition on the same medium as the installer (SD
card or eMMC) as explained here:
https://wiki.postmarketos.org/wiki/On-device_installer

I ended up throwing everything into one module instead of several,
because of a Qt Virtual Keyboard bug:
https://gitlab.com/postmarketOS/postmarketos-ondev/-/issues/18

Based on, but adjusted to be distro-agnostic:
https://gitlab.com/postmarketOS/postmarketos-ondev/-/releases/0.2.1

Closes: calamares/calamares#1451