### PR TITLE
[mobile] make sshd feature optional and related navigation refactoring

### DIFF
--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -19,6 +19,16 @@ cfgStr( const QVariantMap& cfgMap, QString key, QString defaultStr )
     return ret;
 }
 
+bool
+cfgBool( const QVariantMap& cfgMap, QString key, bool defaultBool )
+{
+    if ( cfgMap.contains( key ) )
+    {
+        return cfgMap.value( key ).toBool();
+    }
+    return defaultBool;
+}
+
 void
 Config::setConfigurationMap( const QVariantMap& cfgMap )
 {
@@ -28,6 +38,8 @@ Config::setConfigurationMap( const QVariantMap& cfgMap )
     m_userInterface = cfgStr( cfgMap, "userInterface", "(unknown)" );
     m_version = cfgStr( cfgMap, "version", "(unknown)" );
     m_username = cfgStr( cfgMap, "username", "user" );
+
+    m_featureSshd = cfgBool( cfgMap, "featureSshd", true );
 
     m_cmdLuksFormat = cfgStr( cfgMap, "cmdLuksFormat", "cryptsetup luksFormat --use-random" );
     m_cmdLuksOpen = cfgStr( cfgMap, "cmdLuksOpen", "cryptsetup luksOpen" );

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -19,6 +19,7 @@ class Config : public QObject
     Q_PROPERTY( QString userPassword READ userPassword WRITE setUserPassword NOTIFY userPasswordChanged )
 
     /* ssh server + credentials */
+    Q_PROPERTY( bool featureSshd READ featureSshd CONSTANT FINAL )
     Q_PROPERTY( QString sshdUsername READ sshdUsername WRITE setSshdUsername NOTIFY sshdUsernameChanged )
     Q_PROPERTY( QString sshdPassword READ sshdPassword WRITE setSshdPassword NOTIFY sshdPasswordChanged )
     Q_PROPERTY( bool isSshEnabled READ isSshEnabled WRITE setIsSshEnabled )
@@ -55,6 +56,7 @@ public:
     void setUserPassword( const QString& userPassword );
 
     /* ssh server + credetials */
+    bool featureSshd() { return m_featureSshd; }
     QString sshdUsername() const { return m_sshdUsername; }
     QString sshdPassword() const { return m_sshdPassword; }
     bool isSshEnabled() { return m_isSshEnabled; }
@@ -94,6 +96,7 @@ private:
     QString m_userPassword;
 
     /* ssh server + credetials */
+    bool m_featureSshd;
     QString m_sshdUsername;
     QString m_sshdPassword;
     bool m_isSshEnabled;

--- a/modules/mobile/MobileQmlViewStep.cpp
+++ b/modules/mobile/MobileQmlViewStep.cpp
@@ -54,7 +54,8 @@ MobileQmlViewStep::onLeave()
     /* Put users job in queue (should run after unpackfs) */
     m_jobs.clear();
     QString cmdSshd = m_config->isSshEnabled() ? m_config->cmdSshdEnable() : m_config->cmdSshdDisable();
-    users = new UsersJob( m_config->cmdPasswd(),
+    users = new UsersJob( m_config->featureSshd(),
+                          m_config->cmdPasswd(),
                           cmdSshd,
                           m_config->cmdSshdUseradd(),
                           m_config->isSshEnabled(),

--- a/modules/mobile/UsersJob.cpp
+++ b/modules/mobile/UsersJob.cpp
@@ -12,7 +12,8 @@
 #include <QFileInfo>
 
 
-UsersJob::UsersJob( QString cmdPasswd,
+UsersJob::UsersJob( bool featureSshd,
+                    QString cmdPasswd,
                     QString cmdSshd,
                     QString cmdSshdUseradd,
                     bool isSshEnabled,
@@ -21,6 +22,7 @@ UsersJob::UsersJob( QString cmdPasswd,
                     QString sshdUsername,
                     QString sshdPassword )
     : Calamares::Job()
+    , m_featureSshd( featureSshd )
     , m_cmdPasswd( cmdPasswd )
     , m_cmdSshd( cmdSshd )
     , m_cmdSshdUseradd( cmdSshdUseradd )
@@ -48,14 +50,18 @@ UsersJob::exec()
 
     QList< QPair< QStringList, QString > > commands = {
         { { "sh", "-c", m_cmdPasswd + " " + m_username }, m_password + "\n" + m_password + "\n" },
-        { { "sh", "-c", m_cmdSshd }, QString() },
     };
 
-    if ( m_isSshEnabled )
+    if ( m_featureSshd )
     {
-        commands.append( { { "sh", "-c", m_cmdSshdUseradd + " " + m_sshdUsername }, QString() } );
-        commands.append(
-            { { "sh", "-c", m_cmdPasswd + " " + m_sshdUsername }, m_sshdPassword + "\n" + m_sshdPassword + "\n" } );
+        commands.append( { { "sh", "-c", m_cmdSshd }, QString() } );
+
+        if ( m_isSshEnabled )
+        {
+            commands.append( { { "sh", "-c", m_cmdSshdUseradd + " " + m_sshdUsername }, QString() } );
+            commands.append(
+                { { "sh", "-c", m_cmdPasswd + " " + m_sshdUsername }, m_sshdPassword + "\n" + m_sshdPassword + "\n" } );
+        }
     }
 
     foreach ( auto command, commands )

--- a/modules/mobile/UsersJob.h
+++ b/modules/mobile/UsersJob.h
@@ -8,7 +8,8 @@ class UsersJob : public Calamares::Job
 {
     Q_OBJECT
 public:
-    UsersJob( QString cmdPasswd,
+    UsersJob( bool featureSshd,
+              QString cmdPasswd,
               QString cmdSshd,
               QString cmdSshdUseradd,
               bool isSshEnabled,
@@ -23,6 +24,7 @@ public:
     Calamares::JobList createJobs();
 
 private:
+    bool m_featureSshd;
     QString m_cmdPasswd;
     QString m_cmdSshd;
     QString m_cmdSshdUseradd;

--- a/modules/mobile/default_pin.qml
+++ b/modules/mobile/default_pin.qml
@@ -88,7 +88,7 @@ Item {
         onClicked: {
             if (validatePin(userPin, userPinRepeat, errorText)) {
                 config.userPassword = userPin.text;
-                navTo("ssh_confirm");
+                navNext();
             }
         }
     }

--- a/modules/mobile/fde_confirm.qml
+++ b/modules/mobile/fde_confirm.qml
@@ -46,7 +46,7 @@ Item {
         text: qsTr("Enable")
         onClicked: {
             config.isFdeEnabled = true;
-            navTo("fde_pass");
+            navNext();
         }
     }
 
@@ -59,7 +59,7 @@ Item {
         text: qsTr("Disable")
         onClicked: {
             config.isFdeEnabled = false;
-            navTo("install_confirm");
+            navNextFeature();
         }
     }
 }

--- a/modules/mobile/fde_pass.qml
+++ b/modules/mobile/fde_pass.qml
@@ -73,7 +73,7 @@ Item {
         onClicked: {
             if (validatePassword(password, passwordRepeat, errorText)) {
                 config.fdePassword = password.text;
-                navTo("install_confirm");
+                navNext();
             }
         }
     }

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -30,6 +30,15 @@
 ## Partition that will be formatted and mounted (optionally with FDE) for the rootfs
 # targetDeviceRoot: "/dev/unknown"
 
+######
+### Installer Features
+######
+
+## Ask whether sshd should be enabled or not. If enabled, add a dedicated ssh
+## user with proper username and password and suggest to change to key-based
+## authentication after installation.
+# featureSshd: true
+
 #######
 ### Commands running in the installer OS
 #######

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -166,6 +166,20 @@ Page
     }
     function navNextFeature() {
         var id = featureIdByScreen[screen] + 1;
+
+        /* Skip disabled features by checking "config.featureSshd" etc.*/
+        do {
+            var name = features[id]["name"];
+            var configOption = "feature";
+            configOption += name.charAt(0).toUpperCase();
+            configOption += name.slice(1);
+            if (config[configOption] === false) {
+                console.log("Skipping feature (disabled in config): " + name);
+                id += 1;
+                continue;
+            }
+        } while(false);
+
         console.log("Navigating to feature: " + features[id]["name"]);
         return navTo(features[id]["screens"][0]);
     }

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -122,6 +122,7 @@ Page
 
     /* Navigation related */
     function navTo(name, historyPush=true) {
+        console.log("Navigating to screen: " + name);
         if (historyPush)
             screenPrevious.push(screen);
         screen = name;

--- a/modules/mobile/ssh_confirm.qml
+++ b/modules/mobile/ssh_confirm.qml
@@ -49,7 +49,7 @@ Item {
         text: qsTr("Enable")
         onClicked: {
             config.isSshEnabled = true;
-            navTo("ssh_credentials");
+            navNext();
         }
     }
 
@@ -62,7 +62,7 @@ Item {
         text: qsTr("Disable")
         onClicked: {
             config.isSshEnabled = false;
-            navTo("fde_confirm");
+            navNextFeature();
         }
     }
 }

--- a/modules/mobile/ssh_credentials.qml
+++ b/modules/mobile/ssh_credentials.qml
@@ -100,7 +100,7 @@ Item {
                 config.sshdUsername = username.text;
                 config.sshdPassword = password.text;
 
-                navTo("fde_confirm");
+                navNext();
             }
         }
     }

--- a/modules/mobile/welcome.qml
+++ b/modules/mobile/welcome.qml
@@ -58,7 +58,7 @@ Page
                 width: 500
 
                 text: qsTr("Continue")
-                onClicked: navTo("default_pin")
+                onClicked: navNext()
             }
         }
     }


### PR DESCRIPTION
Some distributions need the sshd feature disabled for now, so make it optional. Refactor the navigation code so we won't get into trouble when making other (possibly new) features optional, too. See commit messages for details.