### PR TITLE
[mobile] Allow distributions to configure expected wait time

### DIFF
--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -25,6 +25,7 @@ Config::setConfigurationMap( const QVariantMap& cfgMap )
     m_userInterface = getString( cfgMap, "userInterface", "(unknown)" );
     m_version = getString( cfgMap, "version", "(unknown)" );
     m_username = getString( cfgMap, "username", "user" );
+    m_waitTime = getString( cfgMap, "waitTime", "20 seconds" );
 
     m_featureSshd = getBool( cfgMap, "featureSshd", true );
 

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -47,6 +47,9 @@ class Config : public QObject
     Q_PROPERTY( QString cmdSshdEnable READ cmdSshdEnable CONSTANT FINAL )
     Q_PROPERTY( QString cmdSshdDisable READ cmdSshdDisable CONSTANT FINAL )
 
+    /* wait */
+    Q_PROPERTY( QString waitTime READ waitTime CONSTANT FINAL )
+
 public:
     Config( QObject* parent = nullptr );
     void setConfigurationMap( const QVariantMap& );
@@ -98,6 +101,9 @@ public:
     QString cmdSshdDisable() const { return m_cmdSshdDisable; }
     QString cmdSshdUseradd() const { return m_cmdSshdUseradd; }
 
+    /* wait */
+    QString waitTime() const { return m_waitTime; }
+
 private:
     /* welcome */
     QString m_osName;
@@ -135,6 +141,9 @@ private:
     QString m_cmdSshdEnable;
     QString m_cmdSshdDisable;
     QString m_cmdSshdUseradd;
+
+    /* wait */
+    QString m_waitTime;
 
 signals:
     /* booleans we don't read from QML (like isSshEnabled) don't need a signal */

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -82,6 +82,10 @@
 ## ondev-internal-storage-prepare.sh in postmarketos-ondev as example.
 # cmdInternalStoragePrepare: "ondev-internal-storage-prepare"
 
+## Wait time text allows the distribution to set the expected time it will take
+## for the PartitionJob to complete.
+# waitTime: "20 seconds"
+
 #######
 ### Commands running in the target OS (chroot)
 #######

--- a/modules/mobile/wait.qml
+++ b/modules/mobile/wait.qml
@@ -38,7 +38,7 @@ Page
             anchors.topMargin: 150
             wrapMode: Text.WordWrap
             text: "Formatting and mounting target partition. This may" +
-                  " take up to 20 seconds, please be patient."
+                  " take up to " + config.waitTime + ", please be patient."
             width: 500
         }
     }


### PR DESCRIPTION
On Mobian, the installer takes far longer than 20 seconds to conduct
this phase of the install. This allows changing the wait time displayed
to the user in order to avoid them restarting, which may cause the installer
to fail on the second attempt.