### PR TITLE
[mobile] wait screen: reword 20s -> 2 min

### DIFF
--- a/modules/mobile/wait.qml
+++ b/modules/mobile/wait.qml
@@ -38,7 +38,7 @@ Page
             anchors.topMargin: 150
             wrapMode: Text.WordWrap
             text: "Formatting and mounting target partition. This may" +
-                  " take up to 20 seconds, please be patient."
+                  " take up to two minutes, please be patient."
             width: 500
         }
     }


### PR DESCRIPTION
Change the message in the wait screen from "This may take up to 20
seconds" to "This may take up to two minutes". That's what Mobian needs,
and with "up to" in the sentence, it's not wrong, even if the actual
time is much shorter.

Creating a config option was considered (#10), but would only add
technical debt since the wait screen is already a hack (as described in
the big comment in `runPartitionJobThenLeave()`).