### PR TITLE
[mobile] support non-numeric passwords

### DIFF
--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -25,6 +25,7 @@ Config::setConfigurationMap( const QVariantMap& cfgMap )
     m_userInterface = getString( cfgMap, "userInterface", "(unknown)" );
     m_version = getString( cfgMap, "version", "(unknown)" );
     m_username = getString( cfgMap, "username", "user" );
+    m_userPasswordNumeric = getBool( cfgMap, "userPasswordNumeric", true );
 
     m_builtinVirtualKeyboard = getBool( cfgMap, "builtinVirtualKeyboard", true );
 

--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -26,6 +26,8 @@ Config::setConfigurationMap( const QVariantMap& cfgMap )
     m_version = getString( cfgMap, "version", "(unknown)" );
     m_username = getString( cfgMap, "username", "user" );
 
+    m_builtinVirtualKeyboard = getBool( cfgMap, "builtinVirtualKeyboard", true );
+
     m_featureSshd = getBool( cfgMap, "featureSshd", true );
     m_featureFsType = getBool( cfgMap, "featureFsType", false );
 

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -23,6 +23,7 @@ class Config : public QObject
     /* default user */
     Q_PROPERTY( QString username READ username CONSTANT FINAL )
     Q_PROPERTY( QString userPassword READ userPassword WRITE setUserPassword NOTIFY userPasswordChanged )
+    Q_PROPERTY( bool userPasswordNumeric READ userPasswordNumeric CONSTANT FINAL )
 
     /* ssh server + credentials */
     Q_PROPERTY( bool featureSshd READ featureSshd CONSTANT FINAL )
@@ -75,6 +76,7 @@ public:
     QString username() const { return m_username; }
     QString userPassword() const { return m_userPassword; }
     void setUserPassword( const QString& userPassword );
+    bool userPasswordNumeric() const { return m_userPasswordNumeric; }
 
     /* ssh server + credetials */
     bool featureSshd() { return m_featureSshd; }
@@ -136,6 +138,7 @@ private:
     /* default user */
     QString m_username;
     QString m_userPassword;
+    bool m_userPasswordNumeric;
 
     /* ssh server + credetials */
     bool m_featureSshd;

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -10,6 +10,9 @@
 class Config : public QObject
 {
     Q_OBJECT
+    /* installer UI */
+    Q_PROPERTY( bool builtinVirtualKeyboard READ builtinVirtualKeyboard CONSTANT FINAL )
+
     /* welcome */
     Q_PROPERTY( QString osName READ osName CONSTANT FINAL )
     Q_PROPERTY( QString arch READ arch CONSTANT FINAL )
@@ -57,6 +60,9 @@ public:
     Config( QObject* parent = nullptr );
     void setConfigurationMap( const QVariantMap& );
     Calamares::JobList createJobs();
+
+    /* installer UI */
+    bool builtinVirtualKeyboard() { return m_builtinVirtualKeyboard; }
 
     /* welcome */
     QString osName() const { return m_osName; }
@@ -117,6 +123,9 @@ public:
     QString cmdSshdUseradd() const { return m_cmdSshdUseradd; }
 
 private:
+    /* installer UI */
+    bool m_builtinVirtualKeyboard;
+
     /* welcome */
     QString m_osName;
     QString m_arch;

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -64,6 +64,10 @@
 ## this gets used without asking the user.
 # defaultFs: ext4
 
+## Start Qt's virtual keyboard within the mobile module. Disable if you bring
+## your own virtual keyboard (e.g. svkbd).
+# builtinVirtualKeyboard: true
+
 #######
 ### Commands running in the installer OS
 #######

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -11,6 +11,10 @@
 ## User Interface name (e.g. Plasma Mobile)
 # userInterface: "(unknown)"
 
+## User Interface assumes that the password is numeric (as of writing, this is
+## the case with Plasma Mobile and Phosh)
+# userPasswordNumeric: true
+
 ## OS version
 # version: "(unknown)"
 

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -208,7 +208,9 @@ Page
                 id += 1;
                 continue;
             }
-        } while(false);
+
+            break;
+        } while (id < features.length);
 
         console.log("Navigating to feature: " + features[id]["name"]);
         return navTo(features[id]["screens"][0]);

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -55,8 +55,8 @@ Page
         }
         return ret;
     }())
-    /* Only allow characters, that can be typed in with the initramfs on-screen keyboard
-     * (osk-sdl: see src/keyboard.cpp). FIXME: make configurable, but keep this as default? */
+    /* Only allow characters, that can be typed in with osk-sdl
+     * (src/keyboard.cpp). Details in big comment in validatePassword(). */
      property var allowed_chars:
         /* layer 0 */ "abcdefghijklmnopqrstuvwxyz" +
         /* layer 1 */ "ABCDEFGHIJKLMNOPQRSTUVWXYZ" +
@@ -389,11 +389,21 @@ Page
         if (pass == "")
             return validationFailure(errorText);
 
+        /* This function gets called for the FDE password and for the user
+         * password. As of writing, all distributions shipping the mobile
+         * module are using osk-sdl to type in the FDE password after the
+         * installation, and another keyboard after booting up, to type in the
+         * user password. The osk-sdl password has the same keys as
+         * squeekboard's default layout, and other keyboards should be able to
+         * type these characters in as well. For now, verify that the password
+         * only contains characters that can be typed in by osk-sdl. If you
+         * need this to be more sophisticated, feel free to submit patches to
+         * make this more configurable. */
         if (!check_chars(pass))
             return validationFailure(errorText,
                                      "The password must only contain" +
-                                     " these characters, others cannot be" +
-                                     " typed in at boot time:\n" +
+                                     " these characters, others can possibly" +
+                                     " not be typed in after installation:\n" +
                                      "\n" +
                                      allowed_chars_multiline());
 

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -19,7 +19,7 @@ Page
         "welcome": null, /* titlebar disabled */
         "install_target": "Installation target",
         "install_target_confirm": "Warning",
-        "default_pin": "Lockscreen PIN",
+        "user_pass": "User password",
         "ssh_confirm": "SSH server",
         "ssh_credentials": "SSH credentials",
         "fs_selection": "Root filesystem",
@@ -33,8 +33,8 @@ Page
          "screens": ["welcome"]},
         {"name": "installTarget",
          "screens": ["install_target", "install_target_confirm"]},
-        {"name": "userPin",
-         "screens": ["default_pin"]},
+        {"name": "userPassword",
+         "screens": ["user_pass"]},
         {"name": "sshd",
          "screens": ["ssh_confirm", "ssh_credentials"]},
         {"name": "fsType",
@@ -46,7 +46,7 @@ Page
     ]
     property var featureIdByScreen: (function() {
         /* Put "features" above into an index of screen name -> feature id:
-         * featureIdByScreen = {"welcome": 0, "default_pin": 1, ...} */
+         * featureIdByScreen = {"welcome": 0, "user_pass": 1, ...} */
         var ret = {};
         for (var i=0; i<features.length; i++) {
             for (var j=0; j<features[i]["screens"].length; j++) {
@@ -253,7 +253,7 @@ Page
         return true;
     }
 
-    /* Input validation: user-screens (default_pin, ssh_credentials) */
+    /* Input validation: user-screens (user_pass, ssh_credentials) */
     function validatePin(userPin, userPinRepeat, errorText) {
         var pin = userPin.text;
         var repeat = userPinRepeat.text;

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -142,6 +142,7 @@ Page
     InputPanel {
         id: inputPanel
         y: Qt.inputMethod.visible ? parent.height - inputPanel.height : parent.height
+        visible: config.builtinVirtualKeyboard
         anchors.left: parent.left
         anchors.right: parent.right
     }

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -184,10 +184,10 @@ Page
         timer.start();
     }
     function navNextFeature() {
-        var id = featureIdByScreen[screen] + 1;
+        var id;
 
         /* Skip disabled features */
-        do {
+        for (id = featureIdByScreen[screen] + 1; id < features.length; id++) {
             /* First letter uppercase */
             var name = features[id]["name"];
             var nameUp = name.charAt(0).toUpperCase() + name.slice(1);
@@ -196,7 +196,6 @@ Page
             var configOption = "feature" + nameUp;
             if (config[configOption] === false) {
                 console.log("Skipping feature (disabled in config): " + name);
-                id += 1;
                 continue;
             }
 
@@ -205,12 +204,11 @@ Page
             if (eval("typeof " + funcName) === "function"
                 && eval(funcName + "()")) {
                 console.log("Skipping feature (skip function): " + name);
-                id += 1;
                 continue;
             }
 
             break;
-        } while (id < features.length);
+        }
 
         console.log("Navigating to feature: " + features[id]["name"]);
         return navTo(features[id]["screens"][0]);

--- a/modules/mobile/mobile.qrc
+++ b/modules/mobile/mobile.qrc
@@ -7,7 +7,7 @@
   <file>install_target.qml</file> <!-- install from external to internal? -->
   <file>install_target_confirm.qml</file> <!-- overwrite internal storage? -->
 
-  <file>default_pin.qml</file> <!-- default user: pin -->
+  <file>user_pass.qml</file> <!-- default user: password -->
   <file>ssh_confirm.qml</file> <!-- sshd: enable or not? -->
   <file>ssh_credentials.qml</file> <!-- sshd user: username, password -->
   <file>fs_selection.qml</file> <!-- filesystem selection -->

--- a/modules/mobile/user_pass.qml
+++ b/modules/mobile/user_pass.qml
@@ -33,11 +33,11 @@ Item {
     }
 
     TextField {
-        id: userPin
+        id: userPass
         anchors.top: description.bottom
         placeholderText: qsTr("PIN")
         echoMode: TextInput.Password
-        onTextChanged: validatePin(userPin, userPinRepeat, errorText)
+        onTextChanged: validatePin(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         /* Let the virtual keyboard change to digits only */
@@ -54,12 +54,12 @@ Item {
     }
 
     TextField {
-        id: userPinRepeat
-        anchors.top: userPin.bottom
+        id: userPassRepeat
+        anchors.top: userPass.bottom
         placeholderText: qsTr("PIN (repeat)")
         inputMethodHints: Qt.ImhDigitsOnly
         echoMode: TextInput.Password
-        onTextChanged: validatePin(userPin, userPinRepeat, errorText)
+        onTextChanged: validatePin(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         anchors.horizontalCenter: parent.horizontalCenter
@@ -68,7 +68,7 @@ Item {
     }
 
     Text {
-        anchors.top: userPinRepeat.bottom
+        anchors.top: userPassRepeat.bottom
         id: errorText
         visible: false
         wrapMode: Text.WordWrap
@@ -86,8 +86,8 @@ Item {
 
         text: qsTr("Continue")
         onClicked: {
-            if (validatePin(userPin, userPinRepeat, errorText)) {
-                config.userPassword = userPin.text;
+            if (validatePin(userPass, userPassRepeat, errorText)) {
+                config.userPassword = userPass.text;
                 navNext();
             }
         }

--- a/modules/mobile/user_pass.qml
+++ b/modules/mobile/user_pass.qml
@@ -12,6 +12,17 @@ import QtQuick.Window 2.3
 import QtQuick.VirtualKeyboard 2.1
 
 Item {
+    property var placeholder: (config.userPasswordNumeric
+                               ? "PIN"
+                               : "Password")
+    property var hints: (config.userPasswordNumeric
+                         ? Qt.ImhDigitsOnly
+                         : Qt.ImhPreferLowercase)
+    property var validateFunc: (config.userPasswordNumeric
+                                ? validatePin
+                                : validatePassword);
+
+
     anchors.left: parent.left
     anchors.top: parent.top
     anchors.right: parent.right
@@ -25,9 +36,17 @@ Item {
         anchors.topMargin: 30
         wrapMode: Text.WordWrap
 
-        text: "Set the numeric password of your user. The lockscreen will" +
-              " ask for this PIN. This is <i>not</i> the PIN of your SIM" +
-              " card. Make sure to remember it."
+        text: (function() {
+            if (config.userPasswordNumeric) {
+                return "Set the numeric password of your user. The" +
+                       " lockscreen will ask for this PIN. This is" +
+                       " <i>not</i> the PIN of your SIM card. Make sure to" +
+                       " remember it.";
+            } else {
+                return "Set the password of your user. The lockscreen will" +
+                      " ask for this password. Make sure to remember it.";
+            }
+        }())
 
         width: 500
     }
@@ -35,13 +54,13 @@ Item {
     TextField {
         id: userPass
         anchors.top: description.bottom
-        placeholderText: qsTr("PIN")
+        placeholderText: qsTr(placeholder)
         echoMode: TextInput.Password
-        onTextChanged: validatePin(userPass, userPassRepeat, errorText)
+        onTextChanged: validateFunc(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         /* Let the virtual keyboard change to digits only */
-        inputMethodHints: Qt.ImhDigitsOnly
+        inputMethodHints: hints
         onActiveFocusChanged: {
             if(activeFocus) {
                 Qt.inputMethod.update(Qt.ImQueryInput)
@@ -56,10 +75,10 @@ Item {
     TextField {
         id: userPassRepeat
         anchors.top: userPass.bottom
-        placeholderText: qsTr("PIN (repeat)")
-        inputMethodHints: Qt.ImhDigitsOnly
+        placeholderText: qsTr(placeholder + " (repeat)")
+        inputMethodHints: hints
         echoMode: TextInput.Password
-        onTextChanged: validatePin(userPass, userPassRepeat, errorText)
+        onTextChanged: validateFunc(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         anchors.horizontalCenter: parent.horizontalCenter
@@ -86,7 +105,7 @@ Item {
 
         text: qsTr("Continue")
         onClicked: {
-            if (validatePin(userPass, userPassRepeat, errorText)) {
+            if (validateFunc(userPass, userPassRepeat, errorText)) {
                 config.userPassword = userPass.text;
                 navNext();
             }


### PR DESCRIPTION
Interface Sxmo does not require a numeric password, so let's add an option that allows to disable the numeric password. Also there is work being done to allow non-numeric passwords in Phosh ([phosh!801](https://source.puri.sm/Librem5/phosh/-/merge_requests/801)).

While at it, add an option to disable the built-in virtual keyboard and fix a bug I found while developing this, navNextFeature wasn't able to skip more than one disabled feature at the same time.

Find details in the commit messages.

CC: @adriaandegroot, @undef-a