### PR TITLE
CMakeLists: Respect CXXFLAGS from environment

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -58,6 +58,7 @@ project(calamares-extensions
     LANGUAGES CXX
 )
 
+set( CMAKE_CXX_FLAGS_RELEASE "${CXXFLAGS}" )
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 


### PR DESCRIPTION
This allows distributions (such as Debian) that set environmental
variables to configure build flags to configure CXXFLAGS.