### PR TITLE
[refind] adding a simple rEFInd module

### DIFF
--- a/modules/refind/main.py
+++ b/modules/refind/main.py
@@ -27,27 +27,16 @@ def pretty_name():
     return _("Install rEFInd.")
 
 def get_uuid():
-    """
-    Checks and passes 'uuid' to other routine.
-
-    :return:
-    """
-    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
     partitions = libcalamares.globalstorage.value("partitions")
     for partition in partitions:
         if partition["mountPoint"] == "/":
             libcalamares.utils.debug(partition["uuid"])
             return partition["uuid"]
-    return ""
+    return None
 
 def update_conf(uuid, conf_path):
     """
     Updates the created rEFInd configuration file based on given parameters.
-
-    :param install_path:
-    :param efi_dir:
-    :param uuid:
-    :param kernel_type:
     """
     partitions = libcalamares.globalstorage.value("partitions")
 
@@ -100,7 +89,7 @@ def update_conf(uuid, conf_path):
     refind_file.close()
 
 
-def install_refind(boot_loader):
+def install_refind():
     install_path = libcalamares.globalstorage.value("rootMountPoint")
     uuid = get_uuid()
     conf_path = os.path.join(install_path, "boot/refind_linux.conf")
@@ -131,7 +120,6 @@ def install_refind(boot_loader):
     update_conf(uuid, conf_path)
 
 def run():
-    boot_loader = libcalamares.globalstorage.value("bootLoader")
     """
     Optional entry for when providing bootloader choices.
     Values taken from a packagechooser instance.
@@ -139,8 +127,8 @@ def run():
     """
     bootchoice = libcalamares.globalstorage.value("packagechooser_bootchoice")
 
-    if bootchoice != 'refind':
+    if bootchoice != "refind":
         return None
 
-    install_refind(boot_loader)
+    install_refind()
     return None

--- a/modules/refind/main.py
+++ b/modules/refind/main.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+#
+# === This file is part of Calamares - <https://calamares.io> ===
+#
+#   SPDX-FileCopyrightText: 2021 Anke Boersma <demm@kaosx.us>
+#   SPDX-License-Identifier: GPL-3.0-or-later
+#
+#   Calamares is Free Software: see the License-Identifier above.
+#
+
+import libcalamares
+
+import os
+import subprocess
+
+from libcalamares.utils import check_target_env_call
+
+import gettext
+_ = gettext.translation("calamares-python",
+                        localedir=libcalamares.utils.gettext_path(),
+                        languages=libcalamares.utils.gettext_languages(),
+                        fallback=True).gettext
+
+
+def pretty_name():
+    return _("Install rEFInd.")
+
+def get_uuid():
+    """
+    Checks and passes 'uuid' to other routine.
+
+    :return:
+    """
+    root_mount_point = libcalamares.globalstorage.value("rootMountPoint")
+    partitions = libcalamares.globalstorage.value("partitions")
+    for partition in partitions:
+        if partition["mountPoint"] == "/":
+            libcalamares.utils.debug(partition["uuid"])
+            return partition["uuid"]
+    return ""
+
+def update_conf(uuid, conf_path):
+    """
+    Updates the created rEFInd configuration file based on given parameters.
+
+    :param install_path:
+    :param efi_dir:
+    :param uuid:
+    :param kernel_type:
+    """
+    partitions = libcalamares.globalstorage.value("partitions")
+
+    kernel_params = ["quiet systemd.show_status=0"]
+    swap = ""
+    swap_luks = ""
+    cryptdevice_params = []
+    btrfs_params = ""
+
+    for partition in partitions:
+        if partition["fs"] == "linuxswap" and not "luksMapperName" in partition:
+            swap = partition["uuid"]
+
+        if partition["fs"] == "linuxswap" and "luksMapperName" in partition:
+            swap_luks = partition["luksMapperName"]
+
+        if partition["mountPoint"] == "/" and "luksMapperName" in partition:
+            cryptdevice_params = [
+                "cryptdevice=UUID={!s}:{!s}".format(partition["luksUuid"],
+                                                    partition["luksMapperName"]),
+                "root=/dev/mapper/{!s}".format(partition["luksMapperName"]),
+                "resume=/dev/mapper/{!s}".format(partition["luksMapperName"])
+            ]
+
+        # rEFInd with a BTRFS root filesystem needs to be told
+        # about the root subvolume.
+        if partition["mountPoint"] == "/" and partition["fs"] == "btrfs":
+            btrfs_params = "rootflags=subvol=@"
+
+    if cryptdevice_params:
+        kernel_params.extend(cryptdevice_params)
+    else:
+        kernel_params.append("root=UUID={!s}".format(uuid))
+
+    if swap:
+        kernel_params.append("resume=UUID={!s}".format(swap))
+    if swap_luks:
+        kernel_params.append("resume=/dev/mapper/{!s}".format(swap_luks))
+    if btrfs_params:
+        kernel_params.append(btrfs_params)
+
+    with open(conf_path, "r") as refind_file:
+        filedata = [x.strip() for x in refind_file.readlines()]
+
+    with open(conf_path, 'w') as refind_file:
+        for line in filedata:
+            if line.startswith('"Boot with standard options"'):
+                line = '"Boot with standard options"    "rw {!s}"'.format(" ".join(kernel_params))
+            refind_file.write(line + "\n")
+    refind_file.close()
+
+
+def install_refind(boot_loader):
+    install_path = libcalamares.globalstorage.value("rootMountPoint")
+    uuid = get_uuid()
+    conf_path = os.path.join(install_path, "boot/refind_linux.conf")
+    partitions = libcalamares.globalstorage.value("partitions")
+    device = ""
+
+    for partition in partitions:
+        if partition["mountPoint"] == "/boot":
+            libcalamares.utils.debug(partition["device"])
+            boot_device = partition["device"]
+            boot_p = boot_device[-1:]
+            device = boot_device[:-1]
+            if boot_device.startswith('/dev/nvme'):
+                device = boot_device[:-2]
+
+            if not boot_p or not device:
+                return ("EFI directory /boot not found!",
+                        "Boot device: \"{!s}\"".format(boot_p, device))
+            else:
+                print("Boot device: \"{!s}\"".format(device))
+
+    if not device:
+        print("WARNING: no EFI system partition or EFI system partition mount point not set.")
+        print("         >>> no EFI bootloader will be installed <<<")
+        return None
+    subprocess.call(
+        ["refind-install", "--root", "{!s}".format(install_path)])
+    update_conf(uuid, conf_path)
+
+def run():
+    boot_loader = libcalamares.globalstorage.value("bootLoader")
+    """
+    Optional entry for when providing bootloader choices.
+    Values taken from a packagechooser instance.
+    Module won't run, if value not present.
+    """
+    bootchoice = libcalamares.globalstorage.value("packagechooser_bootchoice")
+
+    if bootchoice != 'refind':
+        return None
+
+    install_refind(boot_loader)
+    return None

--- a/modules/refind/module.desc
+++ b/modules/refind/module.desc
@@ -1,0 +1,10 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+---
+type:       "job"
+name:       "refind"
+interface:  "python"
+script:     "main.py"
+# The partition module sets up the needed paths in
+# global storage, which is used to decide how to install.
+requiredModules: [ "partition" ]

--- a/modules/refind/refind.conf
+++ b/modules/refind/refind.conf
@@ -1,0 +1,12 @@
+# SPDX-FileCopyrightText: no
+# SPDX-License-Identifier: CC0-1.0
+#
+---
+## This file should be present in the same directory as the EFISTUB kernel and initramfs files
+## More info at http://www.rodsbooks.com/refind/linux.html , http://www.rodsbooks.com/efi-bootloaders/efistub.html
+## File is not needed when rEFInd is installed with the `refind-install` option, it will be created automatically.
+
+#"Boot with defaults"    "root=PARTUUID=XXXXXXXX rootfstype=XXXX rw add_efi_memmap"
+#"Boot to terminal"      "root=PARTUUID=XXXXXXXX rootfstype=XXXX rw add_efi_memmap systemd.unit=multi-user.target"
+
+


### PR DESCRIPTION
takes just 2 options, install in /boot as EFI partition and
uses the refind-install option to install & create needed conf files
no work done to make EFI partiton configurable or choose a manual
option to install.  Those can be added, if there is any interest