### PR TITLE
Enable support for tar option in unpackfsc module for all compression algorithms

### DIFF
--- a/modules/unpackfsc/TarballRunner.cpp
+++ b/modules/unpackfsc/TarballRunner.cpp
@@ -50,14 +50,14 @@ TarballRunner::run()
     // Get the stats (number of inodes) from the FS
     {
         m_total = 0;
-        Calamares::Utils::Runner r( { tarExecutable, QStringLiteral( "-tzf" ), m_source } );
+        Calamares::Utils::Runner r( { tarExecutable, QStringLiteral( "-tf" ), m_source } );
         r.setLocation( Calamares::Utils::RunLocation::RunInHost ).enableOutputProcessing();
         QObject::connect( &r, &decltype( r )::output, [ & ]( QString line ) { m_total++; } );
         /* ignored */ r.run();
     }
     if ( m_total <= 0 )
     {
-        cWarning() << "No stats could be obtained from" << tarExecutable << "-tzf" << m_source;
+        cWarning() << "No stats could be obtained from" << tarExecutable << "-tf" << m_source;
     }
 
     // Now do the actual unpack
@@ -65,7 +65,7 @@ TarballRunner::run()
         m_processed = 0;
         m_since = 0;
         Calamares::Utils::Runner r(
-            { tarExecutable, QStringLiteral( "-xvzf" ), m_source, QStringLiteral( "-C" ), destinationPath } );
+            { tarExecutable, QStringLiteral( "-xpvf" ), m_source, QStringLiteral( "-C" ), destinationPath } );
         r.setLocation( Calamares::Utils::RunLocation::RunInHost ).enableOutputProcessing();
         connect( &r, &decltype( r )::output, this, &TarballRunner::tarballProgress );
         return r.run().explainProcess( toolName, std::chrono::seconds( 0 ) );


### PR DESCRIPTION
Currently the tar option in unpackfsc module only supports gunzip (.gz) compressed files because the `-z` option is hardcoded in the TarballRunner.cpp file.
Removing this option will ensure that the untarring will work on tar files compressed with any compression algorithm including zstd, xz, etc.
Also, `-p` option is added to the untarring command which is the option to preserve file permissions while untarring to the destination. This option is essential while untarring a root filesystem.