### PR TITLE
[mobile] Increase timeout for PartitionJob: 10 min

### DIFF
--- a/modules/mobile/PartitionJob.cpp
+++ b/modules/mobile/PartitionJob.cpp
@@ -118,7 +118,7 @@ PartitionJob::exec()
         const QString pathRoot = "/";
 
         ProcessResult res
-            = System::runCommand( System::RunLocation::RunInHost, args, pathRoot, stdInput, chrono::seconds( 120 ) );
+            = System::runCommand( System::RunLocation::RunInHost, args, pathRoot, stdInput, chrono::seconds( 600 ) );
         if ( res.getExitCode() )
         {
             return JobResult::error( "Command failed:<br><br>"

--- a/modules/mobile/wait.qml
+++ b/modules/mobile/wait.qml
@@ -38,7 +38,7 @@ Page
             anchors.topMargin: 150
             wrapMode: Text.WordWrap
             text: "Formatting and mounting target partition. This may" +
-                  " take up to two minutes, please be patient."
+                  " take up to ten minutes, please be patient."
             width: 500
         }
     }


### PR DESCRIPTION
Increase the PartitionJob's timeout from 2 min to 10 min, as there was a report of hitting the timeout with the PinePhone Pro's 128 GiB eMMC.

Related: https://gitlab.com/postmarketOS/pmaports/-/merge_requests/3280#note_1021536268