### PR TITLE
add username prompt, reservedUsernames config, minor cleanup

### DIFF
--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -30,6 +30,12 @@ Config::setConfigurationMap( const QVariantMap& cfgMap )
     m_device = getString( cfgMap, "device", "(unknown)" );
     m_userInterface = getString( cfgMap, "userInterface", "(unknown)" );
     m_version = getString( cfgMap, "version", "(unknown)" );
+
+    m_reservedUsernames = getStringList( cfgMap, "reservedUsernames", QStringList { "adm", "at ", "bin", "colord",
+            "cron", "cyrus", "daemon", "ftp", "games", "geoclue", "guest", "halt", "lightdm", "lp", "mail", "man",
+            "messagebus", "news", "nobody", "ntp", "operator", "polkitd", "postmaster", "pulse", "root", "shutdown",
+            "smmsp", "squid", "sshd", "sync", "uucp", "vpopmail", "xfs" } );
+
     m_username = getString( cfgMap, "username", "user" );
     m_userPasswordNumeric = getBool( cfgMap, "userPasswordNumeric", true );
 

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -20,6 +20,9 @@ class Config : public QObject
     Q_PROPERTY( QString userInterface READ userInterface CONSTANT FINAL )
     Q_PROPERTY( QString version READ version CONSTANT FINAL )
 
+    /* reserved usernames (user_pass, ssh_credentials )*/
+    Q_PROPERTY( QStringList reservedUsernames READ reservedUsernames CONSTANT FINAL )
+
     /* default user */
     Q_PROPERTY( QString username READ username CONSTANT FINAL )
     Q_PROPERTY( QString userPassword READ userPassword WRITE setUserPassword NOTIFY userPasswordChanged )
@@ -71,6 +74,9 @@ public:
     QString device() const { return m_device; }
     QString userInterface() const { return m_userInterface; }
     QString version() const { return m_version; }
+
+    /* reserved usernames (user_pass, ssh_credentials) */
+    QStringList reservedUsernames() const { return m_reservedUsernames; };
 
     /* default user */
     QString username() const { return m_username; }
@@ -134,6 +140,9 @@ private:
     QString m_device;
     QString m_userInterface;
     QString m_version;
+
+    /* reserved usernames (user_pass, ssh_credentials) */
+    QStringList m_reservedUsernames;
 
     /* default user */
     QString m_username;

--- a/modules/mobile/Config.h
+++ b/modules/mobile/Config.h
@@ -78,7 +78,7 @@ public:
     void setUserPassword( const QString& userPassword );
     bool userPasswordNumeric() const { return m_userPasswordNumeric; }
 
-    /* ssh server + credetials */
+    /* ssh server + credentials */
     bool featureSshd() { return m_featureSshd; }
     QString sshdUsername() const { return m_sshdUsername; }
     QString sshdPassword() const { return m_sshdPassword; }

--- a/modules/mobile/mobile.conf
+++ b/modules/mobile/mobile.conf
@@ -28,6 +28,42 @@ bogus: true
 ## Default username (for which the password will be set)
 # username: "user"
 
+## reserved usernames (for user_pass username prompt and ssh_credentials)
+# reservedUsernames:
+#        - adm
+#        - at
+#        - bin
+#        - colord
+#        - cron
+#        - cyrus
+#        - daemon
+#        - ftp
+#        - games
+#        - geoclue
+#        - guest
+#        - halt
+#        - lightdm
+#        - lp
+#        - mail
+#        - man
+#        - messagebus
+#        - news
+#        - nobody
+#        - ntp
+#        - operator
+#        - polkitd
+#        - postmaster
+#        - pulse
+#        - root
+#        - shutdown
+#        - smmsp
+#        - squid
+#        - sshd
+#        - sync
+#        - uucp
+#        - vpopmail
+#        - xfs
+
 #######
 ### Target device information
 #######

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -280,42 +280,7 @@ Page
     }
     function validateUsername(username, errorText, extraReservedUsernames = []) {
         var name = username.text;
-        var reserved = [ /* FIXME: make configurable */
-            ...extraReservedUsernames,
-            "adm",
-            "at ",
-            "bin",
-            "colord",
-            "cron",
-            "cyrus",
-            "daemon",
-            "ftp",
-            "games",
-            "geoclue",
-            "guest",
-            "halt",
-            "lightdm",
-            "lp",
-            "mail",
-            "man",
-            "messagebus",
-            "news",
-            "nobody",
-            "ntp",
-            "operator",
-            "polkitd",
-            "postmaster",
-            "pulse",
-            "root",
-            "shutdown",
-            "smmsp",
-            "squid",
-            "sshd",
-            "sync",
-            "uucp",
-            "vpopmail",
-            "xfs"
-        ];
+        var reserved = config.reservedUsernames.concat(extraReservedUsernames);
 
         /* Validate characters */
         for (var i = 0; i < name.length; i++) {

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -253,7 +253,7 @@ Page
         return true;
     }
 
-    /* Input validation: user-screens (user_pass, ssh_credentials) */
+    /* Input validation: user-screens (fde_pass, user_pass, ssh_credentials) */
     function validatePin(userPin, userPinRepeat, errorText) {
         var pin = userPin.text;
         var repeat = userPinRepeat.text;
@@ -278,10 +278,10 @@ Page
 
         return validationFailureClear(errorText);
     }
-    function validateSshdUsername(username, errorText) {
+    function validateUsername(username, errorText, extraReservedUsernames = []) {
         var name = username.text;
         var reserved = [ /* FIXME: make configurable */
-            config.username,
+            ...extraReservedUsernames,
             "adm",
             "at ",
             "bin",
@@ -314,8 +314,8 @@ Page
             "sync",
             "uucp",
             "vpopmail",
-            "xfs",
-        ]
+            "xfs"
+        ];
 
         /* Validate characters */
         for (var i = 0; i < name.length; i++) {
@@ -339,11 +339,15 @@ Page
             if (name == reserved[i])
                 return validationFailure(errorText, "Username '" +
                                                     reserved[i] +
-                                                    "' is reserved.")
+                                                    "' is reserved.");
         }
 
         /* Passed */
         return validationFailureClear(errorText);
+    }
+
+    function validateSshdUsername(username, errorText) {
+        return validateUsername(username, errorText, [config.username]);
     }
     function validateSshdPassword(password, passwordRepeat, errorText) {
         var pass = password.text;
@@ -365,8 +369,6 @@ Page
 
         return validationFailureClear(errorText);
     }
-
-    /* Input validation: fde_pass */
     function check_chars(input) {
         for (var i = 0; i < input.length; i++) {
             if (allowed_chars.indexOf(input[i]) == -1)

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -318,7 +318,7 @@ Page
         ]
 
         /* Validate characters */
-        for (var i=0; i<name.length; i++) {
+        for (var i = 0; i < name.length; i++) {
             if (i) {
                 if (!name[i].match(/^[a-z0-9_-]$/))
                     return validationFailure(errorText,
@@ -335,7 +335,7 @@ Page
         }
 
         /* Validate against reserved usernames */
-        for (var i=0;i<reserved.length;i++) {
+        for (var i = 0; i < reserved.length; i++) {
             if (name == reserved[i])
                 return validationFailure(errorText, "Username '" +
                                                     reserved[i] +

--- a/modules/mobile/user_pass.qml
+++ b/modules/mobile/user_pass.qml
@@ -12,15 +12,17 @@ import QtQuick.Window 2.3
 import QtQuick.VirtualKeyboard 2.1
 
 Item {
-    property var placeholder: (config.userPasswordNumeric
+    property var passPlaceholder: (config.userPasswordNumeric
                                ? "PIN"
                                : "Password")
     property var hints: (config.userPasswordNumeric
                          ? Qt.ImhDigitsOnly
                          : Qt.ImhPreferLowercase)
-    property var validateFunc: (config.userPasswordNumeric
+    property var validatePassFunc: (config.userPasswordNumeric
                                 ? validatePin
                                 : validatePassword);
+
+    property var validateNameFunc: validateUsername;
 
 
     anchors.left: parent.left
@@ -30,9 +32,35 @@ Item {
     height: parent.height
 
     Text {
-        id: description
+        id: usernameDescription
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
+        anchors.topMargin: 30
+        wrapMode: Text.WordWrap
+
+        text: (function() {
+            return "Set the username of your user. The default" +
+                   " username is \"" + config.username + "\".";
+        }())
+
+        width: 500
+    }
+
+    TextField {
+        id: username
+        anchors.top: usernameDescription.bottom
+        placeholderText: qsTr("Username")
+        onTextChanged: validateNameFunc(username, errorText)
+        text: config.username
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.topMargin: 50
+        width: 500
+    }
+
+    Text {
+        id: userPassDescription
+        anchors.horizontalCenter: parent.horizontalCenter
+        anchors.top: username.bottom
         anchors.topMargin: 30
         wrapMode: Text.WordWrap
 
@@ -53,10 +81,10 @@ Item {
 
     TextField {
         id: userPass
-        anchors.top: description.bottom
-        placeholderText: qsTr(placeholder)
+        anchors.top: userPassDescription.bottom
+        placeholderText: qsTr(passPlaceholder)
         echoMode: TextInput.Password
-        onTextChanged: validateFunc(userPass, userPassRepeat, errorText)
+        onTextChanged: validatePassFunc(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         /* Let the virtual keyboard change to digits only */
@@ -75,10 +103,10 @@ Item {
     TextField {
         id: userPassRepeat
         anchors.top: userPass.bottom
-        placeholderText: qsTr(placeholder + " (repeat)")
+        placeholderText: qsTr(passPlaceholder + " (repeat)")
         inputMethodHints: hints
         echoMode: TextInput.Password
-        onTextChanged: validateFunc(userPass, userPassRepeat, errorText)
+        onTextChanged: validatePassFunc(userPass, userPassRepeat, errorText)
         text: config.userPassword
 
         anchors.horizontalCenter: parent.horizontalCenter
@@ -105,8 +133,9 @@ Item {
 
         text: qsTr("Continue")
         onClicked: {
-            if (validateFunc(userPass, userPassRepeat, errorText)) {
+            if (validatePassFunc(userPass, userPassRepeat, errorText) && validateNameFunc(username, errorText)) {
                 config.userPassword = userPass.text;
+                config.username = username.text;
                 navNext();
             }
         }


### PR DESCRIPTION
I created this work for Mobian, and as suggested am sharing here for review and inclusion.  A question is open about where the reserved usernames list comes from; see https://salsa.debian.org/Mobian-team/packages/calamares-extensions/-/merge_requests/4.

> ... Sharing my WIP for early review; should the username prompt be a separate screen, or is it acceptable to add it to the password prompt screen?
> I also wonder how to properly attribute my work ...