### PR TITLE
mobile: change min pass length to 6 digits

### DIFF
--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -321,10 +321,10 @@ Page
         if (pass == "")
             return validationFailure(errorText);
 
-        if (pass.length < 8)
+        if (pass.length < 6)
             return validationFailure(errorText,
-                                     "Too short: needs at least 8" +
-                                     " characters.");
+                                     "Too short: needs at least 6" +
+                                     " digits/characters.");
 
         if (repeat == "")
             return validationFailure(errorText);
@@ -374,10 +374,10 @@ Page
                                      "\n" +
                                      allowed_chars_multiline());
 
-        if (pass.length < 8)
+        if (pass.length < 6)
             return validationFailure(errorText,
-                                     "Too short: needs at least 8" +
-                                     " characters.");
+                                     "Too short: needs at least 6" +
+                                     " digits/characters.");
 
         if (repeat == "")
             return validationFailure(errorText);


### PR DESCRIPTION
Require at least 6 characters instead of 8 and mention that digits can also be used. Most users set something like a 6 digit number on their lockscreen, it is even what we have by default in the postmarketOS images when you don't use the installer. So requiring 8 in the installer does not make sense.

Fixes: https://gitlab.com/postmarketOS/postmarketos-ondev/-/issues/62