### PR TITLE
mobile: Adjust all sizes for Calamares 3.3.x

### DIFF
--- a/modules/mobile/fde_confirm.qml
+++ b/modules/mobile/fde_confirm.qml
@@ -22,7 +22,7 @@ Item {
         id: mainText
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: "To protect your data in case your device gets stolen," +
@@ -33,15 +33,15 @@ Item {
               " boot your device or access any data on it. Make sure that" +
               " you don't lose this password!"
 
-        width: 500
+        width: 200
     }
 
     Button {
         id: firstButton
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Enable")
         onClicked: {
@@ -53,8 +53,8 @@ Item {
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: firstButton.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Disable")
         onClicked: {

--- a/modules/mobile/fde_pass.qml
+++ b/modules/mobile/fde_pass.qml
@@ -36,7 +36,7 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
 
     TextField {
@@ -49,8 +49,8 @@ Item {
         text: config.fdePassword
 
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
     }
 
     Text {
@@ -59,15 +59,15 @@ Item {
         visible: false
 
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
         wrapMode: Text.WordWrap
     }
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: errorText.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Continue")
         onClicked: {

--- a/modules/mobile/fs_selection.qml
+++ b/modules/mobile/fs_selection.qml
@@ -22,21 +22,21 @@ Item {
         id: mainText
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: "Select the filesystem for root partition. If unsure, leave the default."
 
-        width: 500
+        width: 200
     }
 
     ComboBox {
         id: fsTypeCB
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
-        anchors.topMargin: 40
-        width: 500
-        height: 60
+        anchors.topMargin: 10
+        width: 150
+        height: 30
         editable: false
         model: config.fsList
         /* Save the current state on selection so it is there when the back button is pressed */
@@ -47,8 +47,8 @@ Item {
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: fsTypeCB.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Continue")
         onClicked: {

--- a/modules/mobile/install_confirm.qml
+++ b/modules/mobile/install_confirm.qml
@@ -22,7 +22,7 @@ Item {
         id: mainText
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 25
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: (function() {
@@ -44,15 +44,15 @@ Item {
             return ret;
         }())
 
-        width: 550
+        width: 200
     }
 
     Button {
         id: firstButton
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
-        anchors.topMargin: 20
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Install")
         onClicked: navFinish()

--- a/modules/mobile/install_target.qml
+++ b/modules/mobile/install_target.qml
@@ -22,7 +22,7 @@ Item {
         id: mainText
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: "The installation was started from an external storage medium." +
@@ -32,15 +32,15 @@ Item {
               "<br>" +
               "Where would you like to install " + config.osName + "?"
 
-        width: 500
+        width: 200
     }
 
     Button {
         id: firstButton
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Internal (eMMC)")
         onClicked: {
@@ -52,8 +52,8 @@ Item {
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: firstButton.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("External (SD card)")
         onClicked: {

--- a/modules/mobile/install_target_confirm.qml
+++ b/modules/mobile/install_target_confirm.qml
@@ -22,21 +22,21 @@ Item {
         id: mainText
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
 	text: "Are you sure that you want to overwrite the internal storage?" +
 	      "<br><br>" +
 	      "<b>All existing data on the device will be lost!</b>"
-        width: 500
+        width: 200
     }
 
     Button {
         id: firstButton
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Yes")
         onClicked: {
@@ -47,8 +47,8 @@ Item {
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: firstButton.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("No")
         onClicked: {

--- a/modules/mobile/mobile.qml
+++ b/modules/mobile/mobile.qml
@@ -77,7 +77,7 @@ Page
             Rectangle {
                 id: mobileNavigation
                 width: parent.width
-                height: 60
+                height: 30
                 color: "#e6e4e1"
                 Layout.fillWidth: true
 
@@ -98,8 +98,8 @@ Page
                         text: "<"
 
                         background: Rectangle {
-                            implicitWidth: 32
-                            implicitHeight: 30
+                            implicitWidth: 10
+                            implicitHeight: 7
                             border.color: "#c1bab5"
                             border.width: 1
                             radius: 4
@@ -109,7 +109,7 @@ Page
                         onClicked: navBack()
                     }
                     Rectangle {
-                        implicitHeight: 30
+                        implicitHeight: 10
                         Layout.fillWidth: true
                         color: "#e6e4e1"
 

--- a/modules/mobile/ssh_confirm.qml
+++ b/modules/mobile/ssh_confirm.qml
@@ -36,7 +36,7 @@ Item {
               "More information:<br>" +
               "https://postmarketos.org/ssh"
 
-        width: 500
+        width: 200
     }
 
     Button {
@@ -44,7 +44,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: mainText.bottom
         anchors.topMargin: 40
-        width: 500
+        width: 200
 
         text: qsTr("Enable")
         onClicked: {
@@ -57,7 +57,7 @@ Item {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: firstButton.bottom
         anchors.topMargin: 40
-        width: 500
+        width: 200
 
         text: qsTr("Disable")
         onClicked: {

--- a/modules/mobile/ssh_credentials.qml
+++ b/modules/mobile/ssh_credentials.qml
@@ -34,7 +34,7 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
 
     Text {
@@ -45,7 +45,7 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
 
     TextField {
@@ -59,7 +59,7 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
 
     TextField {
@@ -73,7 +73,7 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
 
     Text {
@@ -84,13 +84,13 @@ Item {
 
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.topMargin: 50
-        width: 500
+        width: 200
     }
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: errorTextPassword.bottom
         anchors.topMargin: 40
-        width: 500
+        width: 200
 
         text: qsTr("Continue")
         onClicked: {

--- a/modules/mobile/user_pass.qml
+++ b/modules/mobile/user_pass.qml
@@ -35,7 +35,7 @@ Item {
         id: usernameDescription
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: parent.top
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: (function() {
@@ -43,7 +43,7 @@ Item {
                    " username is \"" + config.username + "\".";
         }())
 
-        width: 500
+        width: 200
     }
 
     TextField {
@@ -53,15 +53,15 @@ Item {
         onTextChanged: validateNameFunc(username, errorText)
         text: config.username
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
     }
 
     Text {
         id: userPassDescription
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: username.bottom
-        anchors.topMargin: 30
+        anchors.topMargin: 10
         wrapMode: Text.WordWrap
 
         text: (function() {
@@ -76,7 +76,7 @@ Item {
             }
         }())
 
-        width: 500
+        width: 200
     }
 
     TextField {
@@ -96,8 +96,8 @@ Item {
         }
 
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
     }
 
     TextField {
@@ -110,8 +110,8 @@ Item {
         text: config.userPassword
 
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
     }
 
     Text {
@@ -121,15 +121,15 @@ Item {
         wrapMode: Text.WordWrap
 
         anchors.horizontalCenter: parent.horizontalCenter
-        anchors.topMargin: 50
-        width: 500
+        anchors.topMargin: 10
+        width: 200
     }
 
     Button {
         anchors.horizontalCenter: parent.horizontalCenter
         anchors.top: errorText.bottom
-        anchors.topMargin: 40
-        width: 500
+        anchors.topMargin: 10
+        width: 200
 
         text: qsTr("Continue")
         onClicked: {

--- a/modules/mobile/wait.qml
+++ b/modules/mobile/wait.qml
@@ -26,8 +26,8 @@ Page
             id: logo
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: parent.top
-            anchors.topMargin: 50
-            height: 250
+            anchors.topMargin: 10
+            height: 50
             fillMode: Image.PreserveAspectFit
             source: "file:///usr/share/calamares/branding/default-mobile/logo.png"
         }
@@ -35,11 +35,11 @@ Page
             id: waitText
             anchors.horizontalCenter: parent.horizontalCenter
             anchors.top: logo.bottom
-            anchors.topMargin: 150
+            anchors.topMargin: 50
             wrapMode: Text.WordWrap
             text: "Formatting and mounting target partition. This may" +
                   " take up to ten minutes, please be patient."
-            width: 500
+            width: 200
         }
     }
 }

--- a/modules/mobile/welcome.qml
+++ b/modules/mobile/welcome.qml
@@ -28,8 +28,8 @@ Page
                 id: logo
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: parent.top
-                anchors.topMargin: 50
-                height: 250
+                anchors.topMargin: 10
+                height: 50
                 fillMode: Image.PreserveAspectFit
                 source: "file:///usr/share/calamares/branding/default-mobile/logo.png"
             }
@@ -37,7 +37,7 @@ Page
                 id: mainText
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: logo.bottom
-                anchors.topMargin: 50
+                anchors.topMargin: 10
                 horizontalAlignment: Text.AlignRight
                 text: "You are about to install<br>" +
                       "<b>" + config.osName +
@@ -48,14 +48,14 @@ Page
                       "<b>" + config.arch + "</b><br>" +
                       "on your " +
                       "<b>" + config.device + "</b><br>"
-                width: 500
+                width: 200
             }
 
             Button {
                 anchors.horizontalCenter: parent.horizontalCenter
                 anchors.top: mainText.bottom
-                anchors.topMargin: 50
-                width: 500
+                anchors.topMargin: 10
+                width: 200
 
                 text: qsTr("Continue")
                 onClicked: navNext()


### PR DESCRIPTION
Element sizing in Calamares 3.3.x seems to have dramatically changed, with for example a button that was previously fine at width 500 now being huge to the point of causing the installer to overhang the screen.

This reduces the size of most elements such that they fit on a mobile screen again.

Fixes: https://github.com/calamares/calamares/issues/2192

Note: since taking these screenshots I've adjusted all button widths to 200 (the smaller ones were 100). I'm also still unsure whether this is an expected outcome of Calamares 3.3.x or should be considered a bug.
![IMG20230928184013](https://github.com/calamares/calamares-extensions/assets/75462734/50c78aa6-1943-40e0-a40b-25847ef50aae)
![IMG20230928184019](https://github.com/calamares/calamares-extensions/assets/75462734/908a7e8d-ace0-4c83-ac06-eb11e0126506)
![IMG20230928184026](https://github.com/calamares/calamares-extensions/assets/75462734/8593b203-cead-42bb-b0ae-1b12d5032942)
![IMG20230928184037](https://github.com/calamares/calamares-extensions/assets/75462734/68fa88bf-0d0c-4d76-8cb6-7634dcebd6b0)
![IMG20230928184046](https://github.com/calamares/calamares-extensions/assets/75462734/fe3721d8-70c2-4143-9c5c-ad9227b690d4)
![IMG20230928184106](https://github.com/calamares/calamares-extensions/assets/75462734/e0ce6357-12eb-47ee-beae-04a8b365cc14)
![IMG20230928184114](https://github.com/calamares/calamares-extensions/assets/75462734/75abf469-51f5-4231-8231-cbef36f34877)
![IMG20230928184119](https://github.com/calamares/calamares-extensions/assets/75462734/1254b22b-d79a-49e3-8b6c-1aec7fcd8622)
![IMG20230928184136](https://github.com/calamares/calamares-extensions/assets/75462734/57ecd4bd-b6f3-4f30-93ec-653a52eff9be)
