### PR TITLE
mobile: Ensure welcome screen fits on Librem5

### DIFF
--- a/modules/mobile/welcome.qml
+++ b/modules/mobile/welcome.qml
@@ -46,7 +46,7 @@ Page
                       "<b>" + config.userInterface + "</b><br>" +
                       "architecture " +
                       "<b>" + config.arch + "</b><br>" +
-                      "on your " +
+                      "on your <br>" +
                       "<b>" + config.device + "</b><br>"
                 width: 200
             }


### PR DESCRIPTION
Now that the sizing has changed this line overhangs the screen.

Sorry for the second PR in quick succession for the same issue. I only just tested on the Librem5.