### PR TITLE
Fix failure to configure/build with newer CMake and Calamares 3.3.0

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -56,6 +56,28 @@ project(calamares-extensions
 set( CMAKE_CXX_STANDARD 17 )
 set( CMAKE_CXX_STANDARD_REQUIRED ON )
 
+if(WITH_QT6)
+    set(kfname "KF6")
+    set(KF_VERSION 5.240) # KDE Neon weirdness
+else()
+    message(STATUS "Building Calamares with Qt5")
+    set(kfname "KF5")
+    set(KF_VERSION 5.78)
+    # API that was deprecated before Qt 5.15 causes a compile error
+    add_compile_definitions(QT_DISABLE_DEPRECATED_BEFORE=0x050f00)
+endif()
+
+include( FeatureSummary )
+find_package(${kfname}CoreAddons ${KF_VERSION} QUIET)
+set_package_properties(
+    ${kfname}CoreAddons
+    PROPERTIES
+    TYPE REQUIRED
+    DESCRIPTION "KDE Framework CoreAddons"
+    URL "https://api.kde.org/frameworks/"
+    PURPOSE "Essential Framework for AboutData and Macros"
+)
+
 # On developer's machine, the user package registry breaks
 # consumers by loading the developer's config from a build
 # directory (which doesn't have the rest of the config

--- a/modules/mobile/Config.cpp
+++ b/modules/mobile/Config.cpp
@@ -18,7 +18,7 @@ Config::Config( QObject* parent )
 void
 Config::setConfigurationMap( const QVariantMap& cfgMap )
 {
-    using namespace CalamaresUtils;
+    using namespace Calamares;
 
     if ( getBool( cfgMap, "bogus", false ) )
     {

--- a/modules/mobile/PartitionJob.cpp
+++ b/modules/mobile/PartitionJob.cpp
@@ -5,7 +5,7 @@
 #include "GlobalStorage.h"
 #include "JobQueue.h"
 #include "Settings.h"
-#include "utils/CalamaresUtilsSystem.h"
+#include "utils/System.h"
 #include "utils/Logger.h"
 
 #include <QDir>
@@ -75,7 +75,7 @@ Calamares::JobResult
 PartitionJob::exec()
 {
     using namespace Calamares;
-    using namespace CalamaresUtils;
+    using namespace Calamares;
     using namespace std;
 
     const QString pathMount = "/mnt/install";

--- a/modules/mobile/UsersJob.cpp
+++ b/modules/mobile/UsersJob.cpp
@@ -5,7 +5,7 @@
 #include "GlobalStorage.h"
 #include "JobQueue.h"
 #include "Settings.h"
-#include "utils/CalamaresUtilsSystem.h"
+#include "utils/System.h"
 #include "utils/Logger.h"
 
 #include <QDir>
@@ -47,7 +47,7 @@ Calamares::JobResult
 UsersJob::exec()
 {
     using namespace Calamares;
-    using namespace CalamaresUtils;
+    using namespace Calamares;
     using namespace std;
 
     QList< QPair< QStringList, QString > > commands = {

--- a/modules/unpackfsc/FSArchiverRunner.cpp
+++ b/modules/unpackfsc/FSArchiverRunner.cpp
@@ -62,7 +62,7 @@ FSArchiverRunner::checkPrerequisites( QString& fsarchiverExecutable ) const
 Calamares::JobResult
 FSArchiverRunner::checkDestination( QString& destinationPath ) const
 {
-    destinationPath = CalamaresUtils::System::instance()->targetPath( m_destination );
+    destinationPath = Calamares::System::instance()->targetPath( m_destination );
     if ( destinationPath.isEmpty() )
     {
         return Calamares::JobResult::internalError(

--- a/modules/unpackfsc/Runners.cpp
+++ b/modules/unpackfsc/Runners.cpp
@@ -9,7 +9,7 @@
 
 #include "Runners.h"
 
-#include <utils/CalamaresUtilsSystem.h>
+#include <utils/System.h>
 #include <utils/Logger.h>
 
 #include <QFileInfo>

--- a/modules/unpackfsc/TarballRunner.cpp
+++ b/modules/unpackfsc/TarballRunner.cpp
@@ -38,7 +38,7 @@ TarballRunner::run()
             Calamares::JobResult::MissingRequirements );
     }
 
-    const QString destinationPath = CalamaresUtils::System::instance()->targetPath( m_destination );
+    const QString destinationPath = Calamares::System::instance()->targetPath( m_destination );
     if ( destinationPath.isEmpty() )
     {
         return Calamares::JobResult::internalError(

--- a/modules/unpackfsc/UnpackFSCJob.cpp
+++ b/modules/unpackfsc/UnpackFSCJob.cpp
@@ -101,8 +101,8 @@ UnpackFSCJob::exec()
 void
 UnpackFSCJob::setConfigurationMap( const QVariantMap& map )
 {
-    QString source = CalamaresUtils::getString( map, "source" );
-    QString sourceTypeName = CalamaresUtils::getString( map, "sourcefs" );
+    QString source = Calamares::getString( map, "source" );
+    QString sourceTypeName = Calamares::getString( map, "sourcefs" );
     if ( source.isEmpty() || sourceTypeName.isEmpty() )
     {
         cWarning() << "Skipping item with bad source data:" << map;
@@ -115,7 +115,7 @@ UnpackFSCJob::setConfigurationMap( const QVariantMap& map )
         cWarning() << "Skipping item with source type None";
         return;
     }
-    QString destination = CalamaresUtils::getString( map, "destination" );
+    QString destination = Calamares::getString( map, "destination" );
     if ( destination.isEmpty() )
     {
         cWarning() << "Skipping item with empty destination";

--- a/modules/unpackfsc/UnsquashRunner.cpp
+++ b/modules/unpackfsc/UnsquashRunner.cpp
@@ -38,7 +38,7 @@ UnsquashRunner::run()
             Calamares::JobResult::MissingRequirements );
     }
 
-    const QString destinationPath = CalamaresUtils::System::instance()->targetPath( m_destination );
+    const QString destinationPath = Calamares::System::instance()->targetPath( m_destination );
     if ( destinationPath.isEmpty() )
     {
         return Calamares::JobResult::internalError(


### PR DESCRIPTION
This fixes [this Debian bug](https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1057546) and the moves to the new Calamares API from 3.3.0.